### PR TITLE
Re-add jest to install step in makefile.

### DIFF
--- a/makefile
+++ b/makefile
@@ -6,7 +6,7 @@ PRETTIER=node_modules/prettier/bin-prettier.js
 STYLELINT=node_modules/stylelint/bin/stylelint.js
 
 node_modules:
-	npm install clang-format prettier csstree-validator html-validate eslint eslint-config-google stylelint stylelint-order stylelint-config-standard
+	npm install clang-format prettier csstree-validator html-validate jest eslint eslint-config-google stylelint stylelint-order stylelint-config-standard
 
 pretty: node_modules
 	find backstory/src/main -iname *.html | xargs $(PRETTIER) --write


### PR DESCRIPTION
This got accidentally removed during conflict resolution here:
https://github.com/googleinterns/step174-2020/commit/4e7046aba3a43850f274f7c0f5c796da107a9381#diff-cd5dbf3629c558b0104ba8f0937d6816