### PR TITLE
8/4: Rename the getDecision() to generateDecision() & add error throw (fix errors from last PR)

### DIFF
--- a/backstory/src/main/java/com/google/sps/perspective/PerspectiveManager.java
+++ b/backstory/src/main/java/com/google/sps/perspective/PerspectiveManager.java
@@ -26,5 +26,5 @@ interface PerspectiveManager {
    * @param story The story to be analyzed
    * @return An object describing the recommendation resulting from the analysis.
    */
-  public PerspectiveDecision getDecision(String story);
+  public PerspectiveDecision generateDecision(String story);
 }

--- a/backstory/src/main/java/com/google/sps/perspective/PerspectiveManager.java
+++ b/backstory/src/main/java/com/google/sps/perspective/PerspectiveManager.java
@@ -25,6 +25,7 @@ interface PerspectiveManager {
    *
    * @param story The story to be analyzed
    * @return An object describing the recommendation resulting from the analysis.
+   * @throws NoAppropriateStoryException if no story from decision is considered appropriate
    */
-  public PerspectiveDecision generateDecision(String story);
+  public PerspectiveDecision generateDecision(String story) throws NoAppropriateStoryException;
 }

--- a/backstory/src/main/java/com/google/sps/perspective/PerspectiveManagerImpl.java
+++ b/backstory/src/main/java/com/google/sps/perspective/PerspectiveManagerImpl.java
@@ -72,7 +72,8 @@ public class PerspectiveManagerImpl implements PerspectiveManager {
    * @throws NoAppropriateStoryException if no story from decision is considered appropriate
    */
   public PerspectiveDecision generateDecision(String story) throws NoAppropriateStoryException {
-    // TODO: Replace this fake behavior with a real API call, etc.
+    // TODO: Replace this fake behavior with a real API call, etc. Fake behavior here so teammates have stubbed
+    //       version of this class to use in integration. 
 
     // returns default instance of PerspectiveDecision
     return new PerspectiveDecision(story);

--- a/backstory/src/main/java/com/google/sps/perspective/PerspectiveManagerImpl.java
+++ b/backstory/src/main/java/com/google/sps/perspective/PerspectiveManagerImpl.java
@@ -70,7 +70,7 @@ public class PerspectiveManagerImpl implements PerspectiveManager {
    * @param story The story to be analyzed
    * @return An object describing the recommendation resulting from the analysis.
    */
-  public PerspectiveDecision getDecision(String story) {
+  public PerspectiveDecision generateDecision(String story) {
     // TODO: Replace this fake behavior with a real API call, etc.
 
     // returns default instance of PerspectiveDecision

--- a/backstory/src/main/java/com/google/sps/perspective/PerspectiveManagerImpl.java
+++ b/backstory/src/main/java/com/google/sps/perspective/PerspectiveManagerImpl.java
@@ -69,8 +69,9 @@ public class PerspectiveManagerImpl implements PerspectiveManager {
    *
    * @param story The story to be analyzed
    * @return An object describing the recommendation resulting from the analysis.
+   * @throws NoAppropriateStoryException if no story from decision is considered appropriate
    */
-  public PerspectiveDecision generateDecision(String story) {
+  public PerspectiveDecision generateDecision(String story) throws NoAppropriateStoryException {
     // TODO: Replace this fake behavior with a real API call, etc.
 
     // returns default instance of PerspectiveDecision


### PR DESCRIPTION
Implementing [suggestion](https://github.com/googleinterns/step174-2020/pull/123#discussion_r465398150) from PR that had already been merged to rename getDecision() method. Add error throw that was accidentally left out of last PR.