### PR TITLE
Make StoryManager interfaces public for use outside of package.

### DIFF
--- a/backstory/src/main/java/com/google/sps/story/StoryManager.java
+++ b/backstory/src/main/java/com/google/sps/story/StoryManager.java
@@ -18,7 +18,7 @@ import java.io.IOException;
 /**
  * Interface for story generation class.
  */
-interface StoryManager {
+public interface StoryManager {
   /**
    * Returns generated text output.
    */

--- a/backstory/src/main/java/com/google/sps/story/StoryManagerRequestFactory.java
+++ b/backstory/src/main/java/com/google/sps/story/StoryManagerRequestFactory.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 /**
  * Interface for story generation network requests.
  */
-interface StoryManagerRequestFactory {
+public interface StoryManagerRequestFactory {
   /**
    * Builds a PostRequest given parameters. Uses String JSON body
    * to generate headers for Post request.


### PR DESCRIPTION
It appears interfaces without an access tag will assume standard default permission, so public will be needed for access outside its respective folder.