### PR TITLE
8/10: Add requested test to PerspectiveAPIClientTest

### DIFF
--- a/backstory/src/test/java/com/google/sps/perspective/PerspectiveAPIClientTest.java
+++ b/backstory/src/test/java/com/google/sps/perspective/PerspectiveAPIClientTest.java
@@ -16,7 +16,13 @@ package com.google.sps.perspective;
 
 import static org.mockito.Mockito.*;
 
+import au.com.origma.perspectiveapi.v1alpha1.PerspectiveAPI;
+import au.com.origma.perspectiveapi.v1alpha1.models.AnalyzeCommentRequest;
+import au.com.origma.perspectiveapi.v1alpha1.models.AnalyzeCommentRequest.Builder;
 import au.com.origma.perspectiveapi.v1alpha1.models.AttributeType;
+import au.com.origma.perspectiveapi.v1alpha1.models.ContentType;
+import au.com.origma.perspectiveapi.v1alpha1.models.Entry;
+import au.com.origma.perspectiveapi.v1alpha1.models.RequestedAttribute;
 import com.google.common.collect.ImmutableList;
 import com.google.sps.perspective.data.MockPerspectiveAPIFactory;
 import com.google.sps.perspective.data.PerspectiveAPIClient;
@@ -145,5 +151,34 @@ public final class PerspectiveAPIClientTest {
     }
   }
 
-  // TODO: add a test that checks that the correct AnalyzeCommentRequest is passed to PerspectiveAPI
+  /**
+   * Check that the correct AnalyzeCommentRequest is passed to the Perspective API 
+   * by checking all values of AnalyzeCommentRequest that are set by PerspectiveAPIClient.
+   */
+  @Test
+  public void checkRequest() {
+    MockPerspectiveAPIFactory factory = new MockPerspectiveAPIFactory(new HashMap<AttributeType, Float>()); 
+    PerspectiveAPI mockAPI = factory.newInstance();
+    PerspectiveAPIClient client = new PerspectiveAPIClient(mockAPI);
+
+    PerspectiveValues values = client.analyze(DESIRED_TYPES, DEFAULT_TEXT);
+
+    ArgumentCaptor<AnalyzeCommentRequest> requestCaptor = ArgumentCaptor.forClass(AnalyzeCommentRequest.class);
+    verify(mockAPI).analyze(requestCaptor.capture()); 
+
+    AnalyzeCommentRequest actual = requestCaptor.getValue();
+
+    // check that the entry to score and requested attributes are as expected
+    Assert.assertEquals(DEFAULT_TEXT, actual.getComment().getText()); // check text
+    Assert.assertEquals(ContentType.PLAIN_TEXT, actual.getComment().getType()); // check content type
+
+    Map<AttributeType, RequestedAttribute> requestedAttributes = actual.getRequestedAttributes();
+
+    Assert.assertEquals(DESIRED_TYPES.size(), requestedAttributes.size()); // check number of requested types
+    
+    // check that the types requested match
+    for (AttributeType type: DESIRED_TYPES) {
+      Assert.assertTrue(requestedAttributes.containsKey(type));
+    }
+  }
 }


### PR DESCRIPTION
Add a test to `PerspectiveAPIClientTest` to check that the correct `AnalyzeCommentRequest` was passed to the `PerspectiveAPI.` [Test](https://github.com/googleinterns/step174-2020/pull/132#discussion_r466804697) was requested in this PR.