### PR TITLE
8/14: Add more metrics to Content Decision

### DIFF
--- a/backstory/src/main/java/com/google/sps/perspective/data/ContentDecisions.java
+++ b/backstory/src/main/java/com/google/sps/perspective/data/ContentDecisions.java
@@ -22,6 +22,21 @@ import java.util.Map;
  * is appropriate using analysis from Perspective API.
  */
 public class ContentDecisions {
+  
+  // threshold here means that score must be below this threshold 
+  // in order to be considered appropriate.
+
+  /** the threshold for appropriateness for toxicity score */
+  public static final float TOXICITY_THRESHOLD = .7f;
+  /** the threshold for appropriateness for sexually explicit score */
+  public static final float SEXUALLY_EXPLICIT_THRESHOLD = .6f;
+  /** the threshold for appropriateness for profanity score */
+  public static final float PROFANITY_THRESHOLD = .8f;
+  /** the threshold for appropriateness for offensiveness (identity attack) score */
+  public static final float OFFENSIVE_THRESHOLD = .8f;
+  /** the threshold for appropriateness for obscenity score */
+  public static final float OBSCENITY_THRESHOLD = .8f;
+
   /**
    * Overrides default constructor to ensure class can't be instantiated.
    */
@@ -46,6 +61,24 @@ public class ContentDecisions {
     return !isToxic(scores) && !isSexuallyExplicit(scores) && !isProfane(scores)
         && !isOffensive(scores) && !isObscene(scores);
   }
+  
+  /**
+   * Validate both that the map isn't null and that the map has a score.
+   * 
+   * @param attributeTypesToScores the map to be validating
+   * @param attributeType the type to check it has a score for
+   * @throws IllegalArgumentException if the map is null or doesn't have the score
+   */
+  private static void validateMapHasScore(Map<AttributeType, Float> attributeTypesToScores, 
+    AttributeType attributeType) throws IllegalArgumentException {
+
+    if (attributeTypesToScores == null) {
+      throw new IllegalArgumentException("Map (attributeTypesToScores) cannot be null.");
+    } else if (!attributeTypesToScores.containsKey(attributeType)) {
+      throw new IllegalArgumentException(
+          "Map (attributeTypesToScores) does not contain a score for " + attributeType);
+    }
+  }
 
   /**
    * Private helper method to check if content is considered toxic.
@@ -60,16 +93,10 @@ public class ContentDecisions {
    */
   private static boolean isToxic(Map<AttributeType, Float> attributeTypesToScores)
       throws IllegalArgumentException {
-    if (attributeTypesToScores == null) {
-      throw new IllegalArgumentException("Map (attributeTypesToScores) cannot be null.");
-    } else if (!attributeTypesToScores.containsKey(AttributeType.TOXICITY)) {
-      throw new IllegalArgumentException(
-          "Map (attributeTypesToScores) does not contain a toxicity score");
-    }
+    validateMapHasScore(attributeTypesToScores, AttributeType.TOXICITY);
 
     float toxicity = attributeTypesToScores.get(AttributeType.TOXICITY);
-
-    return toxicity >= .7f;
+    return toxicity >= TOXICITY_THRESHOLD;
   }
 
   /**
@@ -85,16 +112,10 @@ public class ContentDecisions {
    */
   private static boolean isSexuallyExplicit(Map<AttributeType, Float> attributeTypesToScores)
       throws IllegalArgumentException {
-    if (attributeTypesToScores == null) {
-      throw new IllegalArgumentException("Map (attributeTypesToScores) cannot be null.");
-    } else if (!attributeTypesToScores.containsKey(AttributeType.SEXUALLY_EXPLICIT)) {
-      throw new IllegalArgumentException(
-          "Map (attributeTypesToScores) does not contain a sexually explicit score");
-    }
+    validateMapHasScore(attributeTypesToScores, AttributeType.SEXUALLY_EXPLICIT);
 
     float sexuallyExplicit = attributeTypesToScores.get(AttributeType.SEXUALLY_EXPLICIT);
-
-    return sexuallyExplicit >= .6f;
+    return sexuallyExplicit >= SEXUALLY_EXPLICIT_THRESHOLD;
   }
 
   /**
@@ -110,16 +131,10 @@ public class ContentDecisions {
    */
   private static boolean isProfane(Map<AttributeType, Float> attributeTypesToScores)
       throws IllegalArgumentException {
-    if (attributeTypesToScores == null) {
-      throw new IllegalArgumentException("Map (attributeTypesToScores) cannot be null.");
-    } else if (!attributeTypesToScores.containsKey(AttributeType.PROFANITY)) {
-      throw new IllegalArgumentException(
-          "Map (attributeTypesToScores) does not contain a profanity score");
-    }
+    validateMapHasScore(attributeTypesToScores, AttributeType.PROFANITY);
 
     float profanity = attributeTypesToScores.get(AttributeType.PROFANITY);
-
-    return profanity >= .8f;
+    return profanity >= PROFANITY_THRESHOLD;
   }
 
   /**
@@ -135,16 +150,10 @@ public class ContentDecisions {
    */
   private static boolean isOffensive(Map<AttributeType, Float> attributeTypesToScores)
       throws IllegalArgumentException {
-    if (attributeTypesToScores == null) {
-      throw new IllegalArgumentException("Map (attributeTypesToScores) cannot be null.");
-    } else if (!attributeTypesToScores.containsKey(AttributeType.IDENTITY_ATTACK)) {
-      throw new IllegalArgumentException(
-          "Map (attributeTypesToScores) does not contain an identity attack score");
-    }
+    validateMapHasScore(attributeTypesToScores, AttributeType.IDENTITY_ATTACK);
 
     float identityAttack = attributeTypesToScores.get(AttributeType.IDENTITY_ATTACK);
-
-    return identityAttack >= .8f;
+    return identityAttack >= OFFENSIVE_THRESHOLD;
   }
 
   /**
@@ -160,15 +169,9 @@ public class ContentDecisions {
    */
   private static boolean isObscene(Map<AttributeType, Float> attributeTypesToScores)
       throws IllegalArgumentException {
-    if (attributeTypesToScores == null) {
-      throw new IllegalArgumentException("Map (attributeTypesToScores) cannot be null.");
-    } else if (!attributeTypesToScores.containsKey(AttributeType.OBSCENE)) {
-      throw new IllegalArgumentException(
-          "Map (attributeTypesToScores) does not contain an obscenity score");
-    }
+    validateMapHasScore(attributeTypesToScores, AttributeType.OBSCENE);
 
     float obscenity = attributeTypesToScores.get(AttributeType.OBSCENE);
-
-    return obscenity >= .8f;
+    return obscenity >= OBSCENITY_THRESHOLD;
   }
 }

--- a/backstory/src/main/java/com/google/sps/perspective/data/ContentDecisions.java
+++ b/backstory/src/main/java/com/google/sps/perspective/data/ContentDecisions.java
@@ -18,8 +18,8 @@ import au.com.origma.perspectiveapi.v1alpha1.models.AttributeType;
 import java.util.Map;
 
 /**
- * Makes a decision on whether or not the story (or content) is appropriate
- * using analysis from Perspective API.
+ * Provides tools to make decision on whether or not the story (or content)
+ * is appropriate using analysis from Perspective API.
  */
 public class ContentDecisions {
   /**
@@ -33,16 +33,18 @@ public class ContentDecisions {
    * Makes decision on whether or not text in perspective value
    * is considered appropriate based on the analysis scores from Perspective API
    * stored in PerspectiveValues object. Returns this decision as a boolean.
-   * Current decision logic is based off whether text considered toxic.
+   * Decision is currently based on scores of toxicity, sexual explicitness,
+   * profanity, offensivity, and obscenity.
    *
    * @param PerspectiveValues the object containing text to be decided on
    *     & the requested analysis from Perspective API to use in making decision.
    * @return true, if content considered appropriate; false, otherwise
    */
   public static boolean makeDecision(PerspectiveValues values) {
-    // currently decision is entirely based on whether content is considered toxic
+    Map<AttributeType, Float> scores = values.getAttributeTypesToScores();
 
-    return !isToxic(values.getAttributeTypesToScores());
+    return !isToxic(scores) && !isSexuallyExplicit(scores) && !isProfane(scores) 
+        && !isOffensive(scores) && !isObscene(scores);
   }
 
   /**
@@ -52,7 +54,7 @@ public class ContentDecisions {
    *
    * @param attributeTypesToScores a map with attribute types mapped to scores from the Perspective
    *     API
-   * @return true, if toxicity score (in attributeTypesToScores) >= 70% toxic; false, if not
+   * @return true, if toxicity score >= 70%; false, if not
    * @throws IllegalArgumentException, if attributeTypesToScores is null or does not contain a
    *     toxicity score
    */
@@ -68,5 +70,105 @@ public class ContentDecisions {
     float toxicity = attributeTypesToScores.get(AttributeType.TOXICITY);
 
     return toxicity >= .7f;
+  }
+
+  /**
+   * Private helper method to check if content is considered sexually explicit.
+   * Threshold for sexually explicit content is a score greater than or equal to 60% 
+   * after experimenting with Perspective API  
+   *
+   * @param attributeTypesToScores a map with attribute types mapped to scores from the Perspective
+   *     API
+   * @return true, if sexually explicit score >= 60%; false, if not
+   * @throws IllegalArgumentException, if attributeTypesToScores is null or does not contain a
+   *     sexually explicit score
+   */
+  private static boolean isSexuallyExplicit(Map<AttributeType, Float> attributeTypesToScores)
+      throws IllegalArgumentException {
+    if (attributeTypesToScores == null) {
+      throw new IllegalArgumentException("Map (attributeTypesToScores) cannot be null.");
+    } else if (!attributeTypesToScores.containsKey(AttributeType.SEXUALLY_EXPLICIT)) {
+      throw new IllegalArgumentException(
+          "Map (attributeTypesToScores) does not contain a sexually explicit score");
+    }
+
+    float sexuallyExplicit = attributeTypesToScores.get(AttributeType.SEXUALLY_EXPLICIT);
+
+    return sexuallyExplicit >= .6f;
+  }
+
+  /**
+   * Private helper method to check if content is considered profane.
+   * Threshold for profane content is a score greater than or equal to 80% 
+   * after experimenting with Perspective API  
+   *
+   * @param attributeTypesToScores a map with attribute types mapped to scores from the Perspective
+   *     API
+   * @return true, if profanity score >= 80%; false, if not
+   * @throws IllegalArgumentException, if attributeTypesToScores is null or does not contain a
+   *     profanity score
+   */
+  private static boolean isProfane(Map<AttributeType, Float> attributeTypesToScores)
+      throws IllegalArgumentException {
+    if (attributeTypesToScores == null) {
+      throw new IllegalArgumentException("Map (attributeTypesToScores) cannot be null.");
+    } else if (!attributeTypesToScores.containsKey(AttributeType.PROFANITY)) {
+      throw new IllegalArgumentException(
+          "Map (attributeTypesToScores) does not contain a profanity score");
+    }
+
+    float profanity = attributeTypesToScores.get(AttributeType.PROFANITY);
+
+    return profanity >= .8f;
+  }
+
+  /**
+   * Private helper method to check if content is considered offensive.
+   * Threshold for offensive content is an identity attack score greater than or equal to 80% 
+   * after experimenting with Perspective API  
+   *
+   * @param attributeTypesToScores a map with attribute types mapped to scores from the Perspective
+   *     API
+   * @return true, if identity attack score >= 80%; false, if not
+   * @throws IllegalArgumentException, if attributeTypesToScores is null or does not contain a
+   *     identity attack score
+   */
+  private static boolean isOffensive(Map<AttributeType, Float> attributeTypesToScores)
+      throws IllegalArgumentException {
+    if (attributeTypesToScores == null) {
+      throw new IllegalArgumentException("Map (attributeTypesToScores) cannot be null.");
+    } else if (!attributeTypesToScores.containsKey(AttributeType.IDENTITY_ATTACK)) {
+      throw new IllegalArgumentException(
+          "Map (attributeTypesToScores) does not contain an identity attack score");
+    }
+
+    float identityAttack = attributeTypesToScores.get(AttributeType.IDENTITY_ATTACK);
+
+    return identityAttack >= .8f;
+  }
+
+  /**
+   * Private helper method to check if content is considered obscene.
+   * Threshold for obscene content is an obscenity score greater than or equal to 80% 
+   * after experimenting with Perspective API  
+   *
+   * @param attributeTypesToScores a map with attribute types mapped to scores from the Perspective
+   *     API
+   * @return true, if obscenity score >= 80%; false, if not
+   * @throws IllegalArgumentException, if attributeTypesToScores is null or does not contain a
+   *     obscenity score
+   */
+  private static boolean isObscene(Map<AttributeType, Float> attributeTypesToScores)
+      throws IllegalArgumentException {
+    if (attributeTypesToScores == null) {
+      throw new IllegalArgumentException("Map (attributeTypesToScores) cannot be null.");
+    } else if (!attributeTypesToScores.containsKey(AttributeType.OBSCENE)) {
+      throw new IllegalArgumentException(
+          "Map (attributeTypesToScores) does not contain an obscenity score");
+    }
+
+    float obscenity = attributeTypesToScores.get(AttributeType.OBSCENE);
+
+    return obscenity >= .8f;
   }
 }

--- a/backstory/src/main/java/com/google/sps/perspective/data/ContentDecisions.java
+++ b/backstory/src/main/java/com/google/sps/perspective/data/ContentDecisions.java
@@ -43,7 +43,7 @@ public class ContentDecisions {
   public static boolean makeDecision(PerspectiveValues values) {
     Map<AttributeType, Float> scores = values.getAttributeTypesToScores();
 
-    return !isToxic(scores) && !isSexuallyExplicit(scores) && !isProfane(scores) 
+    return !isToxic(scores) && !isSexuallyExplicit(scores) && !isProfane(scores)
         && !isOffensive(scores) && !isObscene(scores);
   }
 
@@ -74,8 +74,8 @@ public class ContentDecisions {
 
   /**
    * Private helper method to check if content is considered sexually explicit.
-   * Threshold for sexually explicit content is a score greater than or equal to 60% 
-   * after experimenting with Perspective API  
+   * Threshold for sexually explicit content is a score greater than or equal to 60%
+   * after experimenting with Perspective API
    *
    * @param attributeTypesToScores a map with attribute types mapped to scores from the Perspective
    *     API
@@ -99,8 +99,8 @@ public class ContentDecisions {
 
   /**
    * Private helper method to check if content is considered profane.
-   * Threshold for profane content is a score greater than or equal to 80% 
-   * after experimenting with Perspective API  
+   * Threshold for profane content is a score greater than or equal to 80%
+   * after experimenting with Perspective API
    *
    * @param attributeTypesToScores a map with attribute types mapped to scores from the Perspective
    *     API
@@ -124,8 +124,8 @@ public class ContentDecisions {
 
   /**
    * Private helper method to check if content is considered offensive.
-   * Threshold for offensive content is an identity attack score greater than or equal to 80% 
-   * after experimenting with Perspective API  
+   * Threshold for offensive content is an identity attack score greater than or equal to 80%
+   * after experimenting with Perspective API
    *
    * @param attributeTypesToScores a map with attribute types mapped to scores from the Perspective
    *     API
@@ -149,8 +149,8 @@ public class ContentDecisions {
 
   /**
    * Private helper method to check if content is considered obscene.
-   * Threshold for obscene content is an obscenity score greater than or equal to 80% 
-   * after experimenting with Perspective API  
+   * Threshold for obscene content is an obscenity score greater than or equal to 80%
+   * after experimenting with Perspective API
    *
    * @param attributeTypesToScores a map with attribute types mapped to scores from the Perspective
    *     API

--- a/backstory/src/test/java/com/google/sps/perspective/ContentDecisionsTest.java
+++ b/backstory/src/test/java/com/google/sps/perspective/ContentDecisionsTest.java
@@ -41,6 +41,9 @@ public final class ContentDecisionsTest {
       AttributeType.SEXUALLY_EXPLICIT, AttributeType.PROFANITY, AttributeType.IDENTITY_ATTACK,
       AttributeType.OBSCENE);
 
+  /** default string to use for text */
+  private static final String DEFAULT_TEXT = "foo";
+
   /** a PerspectiveValue object to be used as input for ContentDecisions class */
   private static PerspectiveValues input;
   /** a Map to be used as the attributeTypesToScores field of input */
@@ -63,7 +66,7 @@ public final class ContentDecisionsTest {
   @Test (expected = IllegalArgumentException.class)
   public void nullMapInput() {
     inputScores = null;
-    input = new PerspectiveValues("foo", inputScores);
+    input = new PerspectiveValues(DEFAULT_TEXT, inputScores);
     ContentDecisions.makeDecision(input); // should be the line causing the error
   }
 
@@ -75,7 +78,7 @@ public final class ContentDecisionsTest {
   public void noToxicityScore() {
     inputScores.remove(AttributeType.TOXICITY);
 
-    input = new PerspectiveValues("foo", inputScores); 
+    input = new PerspectiveValues(DEFAULT_TEXT, inputScores); 
     ContentDecisions.makeDecision(input); // should be the line causing the error
   }
 
@@ -87,7 +90,7 @@ public final class ContentDecisionsTest {
   public void noSexuallyExplicitScore() {
     inputScores.remove(AttributeType.SEXUALLY_EXPLICIT);
 
-    input = new PerspectiveValues("foo", inputScores); 
+    input = new PerspectiveValues(DEFAULT_TEXT, inputScores); 
     ContentDecisions.makeDecision(input); // should be the line causing the error
   }
 
@@ -99,7 +102,7 @@ public final class ContentDecisionsTest {
   public void noProfanityScore() {
     inputScores.remove(AttributeType.PROFANITY);
 
-    input = new PerspectiveValues("foo", inputScores); 
+    input = new PerspectiveValues(DEFAULT_TEXT, inputScores); 
     ContentDecisions.makeDecision(input); // should be the line causing the error
   }
 
@@ -111,7 +114,7 @@ public final class ContentDecisionsTest {
   public void noIdentityAttackScore() {
     inputScores.remove(AttributeType.IDENTITY_ATTACK);
 
-    input = new PerspectiveValues("foo", inputScores); 
+    input = new PerspectiveValues(DEFAULT_TEXT, inputScores); 
     ContentDecisions.makeDecision(input); // should be the line causing the error
   }
 
@@ -123,7 +126,7 @@ public final class ContentDecisionsTest {
   public void noObscenityScore() {
     inputScores.remove(AttributeType.OBSCENE);
 
-    input = new PerspectiveValues("foo", inputScores); 
+    input = new PerspectiveValues(DEFAULT_TEXT, inputScores); 
     ContentDecisions.makeDecision(input); // should be the line causing the error
   }
   
@@ -134,18 +137,18 @@ public final class ContentDecisionsTest {
    */
   @Test
   public void checkDecisionForLowToxicity() {
-    // check with a pretty low toxicity (far below 70%)
-    final float VERY_LOW_TOXICITY = .25f;
+    // check with a pretty low toxicity (very below 70%)
+    final float VERY_LOW_TOXICITY = ContentDecisions.TOXICITY_THRESHOLD - .1f;
 
     inputScores.put(AttributeType.TOXICITY, VERY_LOW_TOXICITY);
-    input = new PerspectiveValues("foo", inputScores);
+    input = new PerspectiveValues(DEFAULT_TEXT, inputScores);
 
     Assert.assertTrue(ContentDecisions.makeDecision(input));
 
     // check with a toxicity just below 70%
-    final float LOW_TOXICITY = .69f;
+    final float LOW_TOXICITY = ContentDecisions.TOXICITY_THRESHOLD - .01f;
     inputScores.put(AttributeType.TOXICITY, LOW_TOXICITY);
-    input = new PerspectiveValues("foo", inputScores);
+    input = new PerspectiveValues(DEFAULT_TEXT, inputScores);
 
     Assert.assertTrue(ContentDecisions.makeDecision(input));
   }
@@ -157,10 +160,10 @@ public final class ContentDecisionsTest {
   @Test
   public void checkDecisionForThresholdToxicity() {
     // check with the threshold toxicity
-    final float THRESHOLD_TOXICITY = .7f;
+    final float THRESHOLD_TOXICITY = ContentDecisions.TOXICITY_THRESHOLD;
 
     inputScores.put(AttributeType.TOXICITY, THRESHOLD_TOXICITY);
-    input = new PerspectiveValues("foo", inputScores);
+    input = new PerspectiveValues(DEFAULT_TEXT, inputScores);
 
     Assert.assertEquals(false, ContentDecisions.makeDecision(input));
   }
@@ -172,18 +175,18 @@ public final class ContentDecisionsTest {
   @Test
   public void checkDecisionForHighToxicity() {
     // check with high toxicity (but just above threshold)
-    final float HIGH_TOXICITY = .71f;
+    final float HIGH_TOXICITY = ContentDecisions.TOXICITY_THRESHOLD + .01f;
 
     inputScores.put(AttributeType.TOXICITY, HIGH_TOXICITY);
-    input = new PerspectiveValues("foo", inputScores);
+    input = new PerspectiveValues(DEFAULT_TEXT, inputScores);
 
     Assert.assertEquals(false, ContentDecisions.makeDecision(input));
 
     // check with very high toxicity (well above threshold)
-    final float VERY_HIGH_TOXICITY = .9f;
+    final float VERY_HIGH_TOXICITY = ContentDecisions.TOXICITY_THRESHOLD + .1f;
 
     inputScores.put(AttributeType.TOXICITY, VERY_HIGH_TOXICITY);
-    input = new PerspectiveValues("foo", inputScores);
+    input = new PerspectiveValues(DEFAULT_TEXT, inputScores);
 
     Assert.assertEquals(false, ContentDecisions.makeDecision(input));
   }
@@ -196,17 +199,17 @@ public final class ContentDecisionsTest {
   @Test
   public void checkDecisionForLowSexuallyExplicit() {
     // check with a pretty low sexually explicit score (far below 60%)
-    final float VERY_LOW_SEXUALLY_EXPLICIT = .25f;
+    final float VERY_LOW_SEXUALLY_EXPLICIT = ContentDecisions.SEXUALLY_EXPLICIT_THRESHOLD - .1f;
 
     inputScores.put(AttributeType.SEXUALLY_EXPLICIT, VERY_LOW_SEXUALLY_EXPLICIT);
-    input = new PerspectiveValues("foo", inputScores);
+    input = new PerspectiveValues(DEFAULT_TEXT, inputScores);
 
     Assert.assertTrue(ContentDecisions.makeDecision(input));
 
     // check with a sexually explicit score just below 60%
-    final float LOW_SEXUALLY_EXPLICIT = .59f;
+    final float LOW_SEXUALLY_EXPLICIT = ContentDecisions.SEXUALLY_EXPLICIT_THRESHOLD - .01f;
     inputScores.put(AttributeType.SEXUALLY_EXPLICIT, LOW_SEXUALLY_EXPLICIT);
-    input = new PerspectiveValues("foo", inputScores);
+    input = new PerspectiveValues(DEFAULT_TEXT, inputScores);
 
     Assert.assertTrue(ContentDecisions.makeDecision(input));
   }
@@ -219,10 +222,10 @@ public final class ContentDecisionsTest {
   @Test
   public void checkDecisionForThresholdSexuallyExplicit() {
     // check with the threshold sexually explicit score
-    final float THRESHOLD_SEXUALLY_EXPLICIT = .6f;
+    final float THRESHOLD_SEXUALLY_EXPLICIT = ContentDecisions.SEXUALLY_EXPLICIT_THRESHOLD;
 
     inputScores.put(AttributeType.SEXUALLY_EXPLICIT, THRESHOLD_SEXUALLY_EXPLICIT);
-    input = new PerspectiveValues("foo", inputScores);
+    input = new PerspectiveValues(DEFAULT_TEXT, inputScores);
 
     Assert.assertEquals(false, ContentDecisions.makeDecision(input));
   }
@@ -235,18 +238,18 @@ public final class ContentDecisionsTest {
   @Test
   public void checkDecisionForHighSexuallyExplicit() {
     // check with high sexually explicit score (but just above threshold)
-    final float HIGH_SEXUALLY_EXPLICIT = .61f;
+    final float HIGH_SEXUALLY_EXPLICIT = ContentDecisions.SEXUALLY_EXPLICIT_THRESHOLD + .01f;
 
     inputScores.put(AttributeType.SEXUALLY_EXPLICIT, HIGH_SEXUALLY_EXPLICIT);
-    input = new PerspectiveValues("foo", inputScores);
+    input = new PerspectiveValues(DEFAULT_TEXT, inputScores);
 
     Assert.assertEquals(false, ContentDecisions.makeDecision(input));
 
     // check with very high sexually explicit score (well above threshold)
-    final float VERY_HIGH_SEXUALLY_EXPLICIT = .8f;
+    final float VERY_HIGH_SEXUALLY_EXPLICIT = ContentDecisions.SEXUALLY_EXPLICIT_THRESHOLD + .1f;
 
     inputScores.put(AttributeType.SEXUALLY_EXPLICIT, VERY_HIGH_SEXUALLY_EXPLICIT);
-    input = new PerspectiveValues("foo", inputScores);
+    input = new PerspectiveValues(DEFAULT_TEXT, inputScores);
 
     Assert.assertEquals(false, ContentDecisions.makeDecision(input));
   }
@@ -259,17 +262,18 @@ public final class ContentDecisionsTest {
   @Test
   public void checkDecisionForLowProfanity() {
     // check with a pretty low profanity score (far below 80%)
-    final float VERY_LOW_PROFANITY = .35f;
+    final float VERY_LOW_PROFANITY = ContentDecisions.PROFANITY_THRESHOLD - .1f;
 
     inputScores.put(AttributeType.PROFANITY, VERY_LOW_PROFANITY);
-    input = new PerspectiveValues("foo", inputScores);
+    input = new PerspectiveValues(DEFAULT_TEXT, inputScores);
 
     Assert.assertTrue(ContentDecisions.makeDecision(input));
 
     // check with a sexually explicit score just below 80%
-    final float LOW_PROFANITY = .79f;
+    final float LOW_PROFANITY = ContentDecisions.PROFANITY_THRESHOLD - .01f;
+
     inputScores.put(AttributeType.PROFANITY, LOW_PROFANITY);
-    input = new PerspectiveValues("foo", inputScores);
+    input = new PerspectiveValues(DEFAULT_TEXT, inputScores);
 
     Assert.assertTrue(ContentDecisions.makeDecision(input));
   }
@@ -282,10 +286,10 @@ public final class ContentDecisionsTest {
   @Test
   public void checkDecisionForThresholdProfanity() {
     // check with the threshold sexually explicit score
-    final float THRESHOLD_PROFANITY = .8f;
+    final float THRESHOLD_PROFANITY = ContentDecisions.PROFANITY_THRESHOLD;
 
     inputScores.put(AttributeType.PROFANITY, THRESHOLD_PROFANITY);
-    input = new PerspectiveValues("foo", inputScores);
+    input = new PerspectiveValues(DEFAULT_TEXT, inputScores);
 
     Assert.assertEquals(false, ContentDecisions.makeDecision(input));
   }
@@ -298,18 +302,18 @@ public final class ContentDecisionsTest {
   @Test
   public void checkDecisionForHighProfanity() {
     // check with high profanity score (but just above threshold)
-    final float HIGH_PROFANITY = .81f;
+    final float HIGH_PROFANITY = ContentDecisions.PROFANITY_THRESHOLD + .01f;
 
     inputScores.put(AttributeType.PROFANITY, HIGH_PROFANITY);
-    input = new PerspectiveValues("foo", inputScores);
+    input = new PerspectiveValues(DEFAULT_TEXT, inputScores);
 
     Assert.assertEquals(false, ContentDecisions.makeDecision(input));
 
     // check with very high profanity score (well above threshold)
-    final float VERY_HIGH_PROFANITY = .95f;
+    final float VERY_HIGH_PROFANITY = ContentDecisions.PROFANITY_THRESHOLD + .1f;
 
     inputScores.put(AttributeType.PROFANITY, VERY_HIGH_PROFANITY);
-    input = new PerspectiveValues("foo", inputScores);
+    input = new PerspectiveValues(DEFAULT_TEXT, inputScores);
 
     Assert.assertEquals(false, ContentDecisions.makeDecision(input));
   }
@@ -322,17 +326,18 @@ public final class ContentDecisionsTest {
   @Test
   public void checkDecisionForLowOffensivity() {
     // check with a pretty low identity attack score (far below 80%)
-    final float VERY_LOW_OFFENSIVITY = .35f;
+    final float VERY_LOW_OFFENSIVITY = ContentDecisions.OFFENSIVE_THRESHOLD - .1f;
 
     inputScores.put(AttributeType.IDENTITY_ATTACK, VERY_LOW_OFFENSIVITY);
-    input = new PerspectiveValues("foo", inputScores);
+    input = new PerspectiveValues(DEFAULT_TEXT, inputScores);
 
     Assert.assertTrue(ContentDecisions.makeDecision(input));
 
     // check with a identity attack score just below 80%
-    final float LOW_OFFENSIVITY = .79f;
+    final float LOW_OFFENSIVITY = ContentDecisions.OFFENSIVE_THRESHOLD - .01f;
+
     inputScores.put(AttributeType.IDENTITY_ATTACK, LOW_OFFENSIVITY);
-    input = new PerspectiveValues("foo", inputScores);
+    input = new PerspectiveValues(DEFAULT_TEXT, inputScores);
 
     Assert.assertTrue(ContentDecisions.makeDecision(input));
   }
@@ -345,10 +350,10 @@ public final class ContentDecisionsTest {
   @Test
   public void checkDecisionForThresholdOffensivity() {
     // check with the threshold identity attack score
-    final float THRESHOLD_OFFENSIVITY = .8f;
+    final float THRESHOLD_OFFENSIVITY = ContentDecisions.OFFENSIVE_THRESHOLD;
 
     inputScores.put(AttributeType.IDENTITY_ATTACK, THRESHOLD_OFFENSIVITY);
-    input = new PerspectiveValues("foo", inputScores);
+    input = new PerspectiveValues(DEFAULT_TEXT, inputScores);
 
     Assert.assertEquals(false, ContentDecisions.makeDecision(input));
   }
@@ -361,18 +366,18 @@ public final class ContentDecisionsTest {
   @Test
   public void checkDecisionForHighOffensivity() {
     // check with high identity attack score (but just above threshold)
-    final float HIGH_OFFENSIVITY = .81f;
+    final float HIGH_OFFENSIVITY = ContentDecisions.OFFENSIVE_THRESHOLD + .01f;
 
     inputScores.put(AttributeType.IDENTITY_ATTACK, HIGH_OFFENSIVITY);
-    input = new PerspectiveValues("foo", inputScores);
+    input = new PerspectiveValues(DEFAULT_TEXT, inputScores);
 
     Assert.assertEquals(false, ContentDecisions.makeDecision(input));
 
     // check with very high identity attack score (well above threshold)
-    final float VERY_HIGH_OFFENSIVITY = .95f;
+    final float VERY_HIGH_OFFENSIVITY = ContentDecisions.OFFENSIVE_THRESHOLD + .1f;
 
     inputScores.put(AttributeType.IDENTITY_ATTACK, VERY_HIGH_OFFENSIVITY);
-    input = new PerspectiveValues("foo", inputScores);
+    input = new PerspectiveValues(DEFAULT_TEXT, inputScores);
 
     Assert.assertEquals(false, ContentDecisions.makeDecision(input));
   }
@@ -385,17 +390,18 @@ public final class ContentDecisionsTest {
   @Test
   public void checkDecisionForLowObscenity() {
     // check with a pretty low obscenity score (far below 80%)
-    final float VERY_LOW_OBSCENITY = .35f;
+    final float VERY_LOW_OBSCENITY = ContentDecisions.OBSCENITY_THRESHOLD - .1f;
 
     inputScores.put(AttributeType.OBSCENE, VERY_LOW_OBSCENITY);
-    input = new PerspectiveValues("foo", inputScores);
+    input = new PerspectiveValues(DEFAULT_TEXT, inputScores);
 
     Assert.assertTrue(ContentDecisions.makeDecision(input));
 
     // check with an obscenity score just below 80%
-    final float LOW_OBSCENITY = .79f;
+    final float LOW_OBSCENITY =  ContentDecisions.OBSCENITY_THRESHOLD - .01f;
+
     inputScores.put(AttributeType.OBSCENE, LOW_OBSCENITY);
-    input = new PerspectiveValues("foo", inputScores);
+    input = new PerspectiveValues(DEFAULT_TEXT, inputScores);
 
     Assert.assertTrue(ContentDecisions.makeDecision(input));
   }
@@ -408,10 +414,10 @@ public final class ContentDecisionsTest {
   @Test
   public void checkDecisionForThresholdObscenity() {
     // check with the threshold obscene score
-    final float THRESHOLD_OBSCENITY = .8f;
+    final float THRESHOLD_OBSCENITY = ContentDecisions.OBSCENITY_THRESHOLD;
 
     inputScores.put(AttributeType.OBSCENE, THRESHOLD_OBSCENITY);
-    input = new PerspectiveValues("foo", inputScores);
+    input = new PerspectiveValues(DEFAULT_TEXT, inputScores);
 
     Assert.assertEquals(false, ContentDecisions.makeDecision(input));
   }
@@ -424,18 +430,18 @@ public final class ContentDecisionsTest {
   @Test
   public void checkDecisionForHighObscenity() {
     // check with high obscenity score (but just above threshold)
-    final float HIGH_OBSCENITY = .81f;
+    final float HIGH_OBSCENITY = ContentDecisions.OBSCENITY_THRESHOLD + .01f;
 
     inputScores.put(AttributeType.OBSCENE, HIGH_OBSCENITY);
-    input = new PerspectiveValues("foo", inputScores);
+    input = new PerspectiveValues(DEFAULT_TEXT, inputScores);
 
     Assert.assertEquals(false, ContentDecisions.makeDecision(input));
 
     // check with very high identity attack score (well above threshold)
-    final float VERY_HIGH_OBSCENITY = .95f;
+    final float VERY_HIGH_OBSCENITY = ContentDecisions.OBSCENITY_THRESHOLD + .1f;
 
     inputScores.put(AttributeType.OBSCENE, VERY_HIGH_OBSCENITY);
-    input = new PerspectiveValues("foo", inputScores);
+    input = new PerspectiveValues(DEFAULT_TEXT, inputScores);
 
     Assert.assertEquals(false, ContentDecisions.makeDecision(input));
   }


### PR DESCRIPTION
Add checks for obscenity, profanity, sexually explicit material, and offensive material into the ContentDecisions class in the logic for deciding if stories are appropriate (this should allow us to more effectively filter out non-family friendly material). Add tests to ensure these new metrics are filtering out content.

Note: thresholds set to filter content in this PR were decided based off experimenting with the Perspective API.