### PR TITLE
8/14: Fix bug in Perspective Demo

### DIFF
--- a/backstory/src/demo/java/com/google/sps/servlets/PerspectiveServlet.java
+++ b/backstory/src/demo/java/com/google/sps/servlets/PerspectiveServlet.java
@@ -79,15 +79,9 @@ public final class PerspectiveServlet extends HttpServlet {
     }
 
     // generate a PerspectiveDecision with that manager
-    PerspectiveDecision perspectiveDecision;
-    try {
-      perspectiveDecision = manager.generatePerspectiveDecision(text);
-    } catch (NoAppropriateStoryException e) {
-      perspectiveDecision = null;
-    }
+    PerspectiveDecision perspectiveDecision = manager.generatePerspectiveDecision(text);
 
-    // if perspectiveDecision is null, then it means the decision is not appropriate (should be false)
-    Boolean isAppropriateStory = (perspectiveDecision != null);
+    Boolean isAppropriateStory = perspectiveDecision.hasAppropriateStory();
     PerspectiveValues values = perspectiveDecision.getValues();
 
     // objects to write back on the respones

--- a/backstory/src/main/java/com/google/sps/perspective/PerspectiveStoryAnalysisManager.java
+++ b/backstory/src/main/java/com/google/sps/perspective/PerspectiveStoryAnalysisManager.java
@@ -110,22 +110,14 @@ public class PerspectiveStoryAnalysisManager implements StoryAnalysisManager {
    * as a PerspectiveDecision object (for demo purposes).
    *
    * @param story The story to be analyzed
-   * @return An object describing the recommendation resulting from the analysis.
-   * @throws NoAppropriateStoryException if story is not considered appropriate
+   * @return An object describing the recommendation resulting from the analysis. If the
+   *    the PerspectiveDecision story field is null, it's not an appropriate story.
    */
-  public PerspectiveDecision generatePerspectiveDecision(String story)
-      throws NoAppropriateStoryException {
+  public PerspectiveDecision generatePerspectiveDecision(String story) {
     PerspectiveAPIClient apiClient = new PerspectiveAPIClient(perspectiveAPI);
     PerspectiveValues storyValues = apiClient.analyze(Arrays.asList(REQUESTED_ATTRIBUTES), story);
     boolean isStoryAppropriate = ContentDecisions.makeDecision(storyValues);
 
-    // if content decisions returns that it's appropriate
-    // then return a StoryDecision object with this story
-    if (isStoryAppropriate) {
-      return new PerspectiveDecision(story, storyValues);
-    }
-
-    // otherwise throw the NoAppropriateStoryException
-    throw new NoAppropriateStoryException("The story passed in was not appropriate.");
+    return new PerspectiveDecision(story, isStoryAppropriate, storyValues);
   }
 }

--- a/backstory/src/main/java/com/google/sps/perspective/data/ContentDecisions.java
+++ b/backstory/src/main/java/com/google/sps/perspective/data/ContentDecisions.java
@@ -18,8 +18,8 @@ import au.com.origma.perspectiveapi.v1alpha1.models.AttributeType;
 import java.util.Map;
 
 /**
- * Provides tools to make decision on whether or not the story (or content)
- * is appropriate using analysis from Perspective API.
+ * Makes a decision on whether or not the story (or content) is appropriate
+ * using analysis from Perspective API.
  */
 public class ContentDecisions {
   /**
@@ -33,18 +33,16 @@ public class ContentDecisions {
    * Makes decision on whether or not text in perspective value
    * is considered appropriate based on the analysis scores from Perspective API
    * stored in PerspectiveValues object. Returns this decision as a boolean.
-   * Decision is currently based on scores of toxicity, sexual explicitness,
-   * profanity, offensivity, and obscenity.
+   * Current decision logic is based off whether text considered toxic.
    *
    * @param PerspectiveValues the object containing text to be decided on
    *     & the requested analysis from Perspective API to use in making decision.
    * @return true, if content considered appropriate; false, otherwise
    */
   public static boolean makeDecision(PerspectiveValues values) {
-    Map<AttributeType, Float> scores = values.getAttributeTypesToScores();
+    // currently decision is entirely based on whether content is considered toxic
 
-    return !isToxic(scores) && !isSexuallyExplicit(scores) && !isProfane(scores)
-        && !isOffensive(scores) && !isObscene(scores);
+    return !isToxic(values.getAttributeTypesToScores());
   }
 
   /**
@@ -54,7 +52,7 @@ public class ContentDecisions {
    *
    * @param attributeTypesToScores a map with attribute types mapped to scores from the Perspective
    *     API
-   * @return true, if toxicity score >= 70%; false, if not
+   * @return true, if toxicity score (in attributeTypesToScores) >= 70% toxic; false, if not
    * @throws IllegalArgumentException, if attributeTypesToScores is null or does not contain a
    *     toxicity score
    */
@@ -70,105 +68,5 @@ public class ContentDecisions {
     float toxicity = attributeTypesToScores.get(AttributeType.TOXICITY);
 
     return toxicity >= .7f;
-  }
-
-  /**
-   * Private helper method to check if content is considered sexually explicit.
-   * Threshold for sexually explicit content is a score greater than or equal to 60%
-   * after experimenting with Perspective API
-   *
-   * @param attributeTypesToScores a map with attribute types mapped to scores from the Perspective
-   *     API
-   * @return true, if sexually explicit score >= 60%; false, if not
-   * @throws IllegalArgumentException, if attributeTypesToScores is null or does not contain a
-   *     sexually explicit score
-   */
-  private static boolean isSexuallyExplicit(Map<AttributeType, Float> attributeTypesToScores)
-      throws IllegalArgumentException {
-    if (attributeTypesToScores == null) {
-      throw new IllegalArgumentException("Map (attributeTypesToScores) cannot be null.");
-    } else if (!attributeTypesToScores.containsKey(AttributeType.SEXUALLY_EXPLICIT)) {
-      throw new IllegalArgumentException(
-          "Map (attributeTypesToScores) does not contain a sexually explicit score");
-    }
-
-    float sexuallyExplicit = attributeTypesToScores.get(AttributeType.SEXUALLY_EXPLICIT);
-
-    return sexuallyExplicit >= .6f;
-  }
-
-  /**
-   * Private helper method to check if content is considered profane.
-   * Threshold for profane content is a score greater than or equal to 80%
-   * after experimenting with Perspective API
-   *
-   * @param attributeTypesToScores a map with attribute types mapped to scores from the Perspective
-   *     API
-   * @return true, if profanity score >= 80%; false, if not
-   * @throws IllegalArgumentException, if attributeTypesToScores is null or does not contain a
-   *     profanity score
-   */
-  private static boolean isProfane(Map<AttributeType, Float> attributeTypesToScores)
-      throws IllegalArgumentException {
-    if (attributeTypesToScores == null) {
-      throw new IllegalArgumentException("Map (attributeTypesToScores) cannot be null.");
-    } else if (!attributeTypesToScores.containsKey(AttributeType.PROFANITY)) {
-      throw new IllegalArgumentException(
-          "Map (attributeTypesToScores) does not contain a profanity score");
-    }
-
-    float profanity = attributeTypesToScores.get(AttributeType.PROFANITY);
-
-    return profanity >= .8f;
-  }
-
-  /**
-   * Private helper method to check if content is considered offensive.
-   * Threshold for offensive content is an identity attack score greater than or equal to 80%
-   * after experimenting with Perspective API
-   *
-   * @param attributeTypesToScores a map with attribute types mapped to scores from the Perspective
-   *     API
-   * @return true, if identity attack score >= 80%; false, if not
-   * @throws IllegalArgumentException, if attributeTypesToScores is null or does not contain a
-   *     identity attack score
-   */
-  private static boolean isOffensive(Map<AttributeType, Float> attributeTypesToScores)
-      throws IllegalArgumentException {
-    if (attributeTypesToScores == null) {
-      throw new IllegalArgumentException("Map (attributeTypesToScores) cannot be null.");
-    } else if (!attributeTypesToScores.containsKey(AttributeType.IDENTITY_ATTACK)) {
-      throw new IllegalArgumentException(
-          "Map (attributeTypesToScores) does not contain an identity attack score");
-    }
-
-    float identityAttack = attributeTypesToScores.get(AttributeType.IDENTITY_ATTACK);
-
-    return identityAttack >= .8f;
-  }
-
-  /**
-   * Private helper method to check if content is considered obscene.
-   * Threshold for obscene content is an obscenity score greater than or equal to 80%
-   * after experimenting with Perspective API
-   *
-   * @param attributeTypesToScores a map with attribute types mapped to scores from the Perspective
-   *     API
-   * @return true, if obscenity score >= 80%; false, if not
-   * @throws IllegalArgumentException, if attributeTypesToScores is null or does not contain a
-   *     obscenity score
-   */
-  private static boolean isObscene(Map<AttributeType, Float> attributeTypesToScores)
-      throws IllegalArgumentException {
-    if (attributeTypesToScores == null) {
-      throw new IllegalArgumentException("Map (attributeTypesToScores) cannot be null.");
-    } else if (!attributeTypesToScores.containsKey(AttributeType.OBSCENE)) {
-      throw new IllegalArgumentException(
-          "Map (attributeTypesToScores) does not contain an obscenity score");
-    }
-
-    float obscenity = attributeTypesToScores.get(AttributeType.OBSCENE);
-
-    return obscenity >= .8f;
   }
 }

--- a/backstory/src/main/java/com/google/sps/perspective/data/ContentDecisions.java
+++ b/backstory/src/main/java/com/google/sps/perspective/data/ContentDecisions.java
@@ -18,8 +18,8 @@ import au.com.origma.perspectiveapi.v1alpha1.models.AttributeType;
 import java.util.Map;
 
 /**
- * Makes a decision on whether or not the story (or content) is appropriate
- * using analysis from Perspective API.
+ * Provides tools to make decision on whether or not the story (or content)
+ * is appropriate using analysis from Perspective API.
  */
 public class ContentDecisions {
   
@@ -48,16 +48,18 @@ public class ContentDecisions {
    * Makes decision on whether or not text in perspective value
    * is considered appropriate based on the analysis scores from Perspective API
    * stored in PerspectiveValues object. Returns this decision as a boolean.
-   * Current decision logic is based off whether text considered toxic.
+   * Decision is currently based on scores of toxicity, sexual explicitness,
+   * profanity, offensivity, and obscenity.
    *
    * @param PerspectiveValues the object containing text to be decided on
    *     & the requested analysis from Perspective API to use in making decision.
    * @return true, if content considered appropriate; false, otherwise
    */
   public static boolean makeDecision(PerspectiveValues values) {
-    // currently decision is entirely based on whether content is considered toxic
+    Map<AttributeType, Float> scores = values.getAttributeTypesToScores();
 
-    return !isToxic(values.getAttributeTypesToScores());
+    return !isToxic(scores) && !isSexuallyExplicit(scores) && !isProfane(scores)
+        && !isOffensive(scores) && !isObscene(scores);
   }
   
   /**
@@ -85,7 +87,7 @@ public class ContentDecisions {
    *
    * @param attributeTypesToScores a map with attribute types mapped to scores from the Perspective
    *     API
-   * @return true, if toxicity score (in attributeTypesToScores) >= 70% toxic; false, if not
+   * @return true, if toxicity score >= 70%; false, if not
    * @throws IllegalArgumentException, if attributeTypesToScores is null or does not contain a
    *     toxicity score
    */

--- a/backstory/src/main/java/com/google/sps/perspective/data/ContentDecisions.java
+++ b/backstory/src/main/java/com/google/sps/perspective/data/ContentDecisions.java
@@ -22,8 +22,7 @@ import java.util.Map;
  * is appropriate using analysis from Perspective API.
  */
 public class ContentDecisions {
-  
-  // threshold here means that score must be below this threshold 
+  // threshold here means that score must be below this threshold
   // in order to be considered appropriate.
 
   /** the threshold for appropriateness for toxicity score */
@@ -61,17 +60,16 @@ public class ContentDecisions {
     return !isToxic(scores) && !isSexuallyExplicit(scores) && !isProfane(scores)
         && !isOffensive(scores) && !isObscene(scores);
   }
-  
+
   /**
    * Validate both that the map isn't null and that the map has a score.
-   * 
+   *
    * @param attributeTypesToScores the map to be validating
    * @param attributeType the type to check it has a score for
    * @throws IllegalArgumentException if the map is null or doesn't have the score
    */
-  private static void validateMapHasScore(Map<AttributeType, Float> attributeTypesToScores, 
-    AttributeType attributeType) throws IllegalArgumentException {
-
+  private static void validateMapHasScore(Map<AttributeType, Float> attributeTypesToScores,
+      AttributeType attributeType) throws IllegalArgumentException {
     if (attributeTypesToScores == null) {
       throw new IllegalArgumentException("Map (attributeTypesToScores) cannot be null.");
     } else if (!attributeTypesToScores.containsKey(attributeType)) {

--- a/backstory/src/main/java/com/google/sps/perspective/data/PerspectiveDecision.java
+++ b/backstory/src/main/java/com/google/sps/perspective/data/PerspectiveDecision.java
@@ -19,6 +19,8 @@ package com.google.sps.perspective.data;
  * appropriate story) but the values used to make that decision.
  */
 public class PerspectiveDecision extends StoryDecision {
+  /** whether or not this decision has an appropriate story */
+  private final boolean hasAppropriateStory;
   /** the values of the story  */
   private final PerspectiveValues values;
 
@@ -29,11 +31,21 @@ public class PerspectiveDecision extends StoryDecision {
    * @param values the values used to make the decision
    * @throws IllegalArgumentException if story is null
    */
-  public PerspectiveDecision(String story, PerspectiveValues values)
+  public PerspectiveDecision(String story, boolean hasAppropriateStory, PerspectiveValues values)
       throws IllegalArgumentException {
     super(story);
 
+    this.hasAppropriateStory = hasAppropriateStory;
     this.values = values;
+  }
+
+  /**
+   * Returns whether there was an appropriate story
+   *
+   * @return true, if there was an appropriate story, false otherwise
+   */
+  public boolean hasAppropriateStory() {
+    return hasAppropriateStory;
   }
 
   /**

--- a/backstory/src/test/java/com/google/sps/perspective/ContentDecisionsTest.java
+++ b/backstory/src/test/java/com/google/sps/perspective/ContentDecisionsTest.java
@@ -17,7 +17,6 @@ package com.google.sps.perspective;
 import static org.mockito.Mockito.*;
 
 import au.com.origma.perspectiveapi.v1alpha1.models.AttributeType;
-import com.google.common.collect.ImmutableList;
 import com.google.sps.perspective.data.ContentDecisions;
 import com.google.sps.perspective.data.PerspectiveValues;
 import java.util.HashMap;
@@ -36,11 +35,6 @@ import org.mockito.stubbing.Answer;
 @RunWith(JUnit4.class)
 public final class ContentDecisionsTest {
 
-  /** the types used as criteria for the content decisions */
-  private static final ImmutableList<AttributeType> CRITERIA = ImmutableList.of(AttributeType.TOXICITY,
-      AttributeType.SEXUALLY_EXPLICIT, AttributeType.PROFANITY, AttributeType.IDENTITY_ATTACK,
-      AttributeType.OBSCENE);
-
   /** a PerspectiveValue object to be used as input for ContentDecisions class */
   private static PerspectiveValues input;
   /** a Map to be used as the attributeTypesToScores field of input */
@@ -49,11 +43,6 @@ public final class ContentDecisionsTest {
   @Before 
   public void setUp() {
     inputScores = new HashMap<AttributeType, Float>();
-
-    // set all criteria to 0 at the moment (so default is it's appropriate)
-    for (AttributeType type: CRITERIA) {
-      inputScores.put(type, 0f);
-    }
   }
 
   /**
@@ -72,61 +61,10 @@ public final class ContentDecisionsTest {
    * to ensure that an IllegalArgumentException will be thrown.
    */
   @Test (expected = IllegalArgumentException.class)
-  public void noToxicityScore() {
-    inputScores.remove(AttributeType.TOXICITY);
-
-    input = new PerspectiveValues("foo", inputScores); 
+  public void noToxicityInput() {
+    input = new PerspectiveValues("foo", inputScores); // no toxicity score has been added yet
     ContentDecisions.makeDecision(input); // should be the line causing the error
   }
-
-  /**
-   * Call makeDecision with a PerspectiveValues with a Map without a sexually explicit score 
-   * to ensure that an IllegalArgumentException will be thrown.
-   */
-  @Test (expected = IllegalArgumentException.class)
-  public void noSexuallyExplicitScore() {
-    inputScores.remove(AttributeType.SEXUALLY_EXPLICIT);
-
-    input = new PerspectiveValues("foo", inputScores); 
-    ContentDecisions.makeDecision(input); // should be the line causing the error
-  }
-
-  /**
-   * Call makeDecision with a PerspectiveValues with a Map without a profanity score 
-   * to ensure that an IllegalArgumentException will be thrown.
-   */
-  @Test (expected = IllegalArgumentException.class)
-  public void noProfanityScore() {
-    inputScores.remove(AttributeType.PROFANITY);
-
-    input = new PerspectiveValues("foo", inputScores); 
-    ContentDecisions.makeDecision(input); // should be the line causing the error
-  }
-
-  /**
-   * Call makeDecision with a PerspectiveValues with a Map without an identity attack score 
-   * to ensure that an IllegalArgumentException will be thrown.
-   */
-  @Test (expected = IllegalArgumentException.class)
-  public void noIdentityAttackScore() {
-    inputScores.remove(AttributeType.IDENTITY_ATTACK);
-
-    input = new PerspectiveValues("foo", inputScores); 
-    ContentDecisions.makeDecision(input); // should be the line causing the error
-  }
-
-  /**
-   * Call makeDecision with a PerspectiveValues with a Map without an obscenity score 
-   * to ensure that an IllegalArgumentException will be thrown.
-   */
-  @Test (expected = IllegalArgumentException.class)
-  public void noObscenityScore() {
-    inputScores.remove(AttributeType.OBSCENE);
-
-    input = new PerspectiveValues("foo", inputScores); 
-    ContentDecisions.makeDecision(input); // should be the line causing the error
-  }
-  
 
   /**
    * Check that ContentDecisions makeDecision returns that PerspectiveValues
@@ -183,258 +121,6 @@ public final class ContentDecisionsTest {
     final float VERY_HIGH_TOXICITY = .9f;
 
     inputScores.put(AttributeType.TOXICITY, VERY_HIGH_TOXICITY);
-    input = new PerspectiveValues("foo", inputScores);
-
-    Assert.assertEquals(false, ContentDecisions.makeDecision(input));
-  }
-
-  /**
-   * Check that ContentDecisions makeDecision returns that PerspectiveValues
-   * with low scores for sexually explicit material (below 60% threshold) 
-   * is appropriate (thus true as return).
-   */
-  @Test
-  public void checkDecisionForLowSexuallyExplicit() {
-    // check with a pretty low sexually explicit score (far below 60%)
-    final float VERY_LOW_SEXUALLY_EXPLICIT = .25f;
-
-    inputScores.put(AttributeType.SEXUALLY_EXPLICIT, VERY_LOW_SEXUALLY_EXPLICIT);
-    input = new PerspectiveValues("foo", inputScores);
-
-    Assert.assertTrue(ContentDecisions.makeDecision(input));
-
-    // check with a sexually explicit score just below 60%
-    final float LOW_SEXUALLY_EXPLICIT = .59f;
-    inputScores.put(AttributeType.SEXUALLY_EXPLICIT, LOW_SEXUALLY_EXPLICIT);
-    input = new PerspectiveValues("foo", inputScores);
-
-    Assert.assertTrue(ContentDecisions.makeDecision(input));
-  }
-
-  /**
-   * Check that ContentDecisions makeDecision() returns that PerspectiveValues
-   * with threshold sexually explicit material (exactly 60%) is inappropiate 
-   * (thus false as return).
-   */
-  @Test
-  public void checkDecisionForThresholdSexuallyExplicit() {
-    // check with the threshold sexually explicit score
-    final float THRESHOLD_SEXUALLY_EXPLICIT = .6f;
-
-    inputScores.put(AttributeType.SEXUALLY_EXPLICIT, THRESHOLD_SEXUALLY_EXPLICIT);
-    input = new PerspectiveValues("foo", inputScores);
-
-    Assert.assertEquals(false, ContentDecisions.makeDecision(input));
-  }
-
-  /**
-   * Check that ContentDecisions returns that PerspectiveValues
-   * with high sexually explicit material (above 60% threshold) 
-   * is inappropiate (thus false as return).
-   */
-  @Test
-  public void checkDecisionForHighSexuallyExplicit() {
-    // check with high sexually explicit score (but just above threshold)
-    final float HIGH_SEXUALLY_EXPLICIT = .61f;
-
-    inputScores.put(AttributeType.SEXUALLY_EXPLICIT, HIGH_SEXUALLY_EXPLICIT);
-    input = new PerspectiveValues("foo", inputScores);
-
-    Assert.assertEquals(false, ContentDecisions.makeDecision(input));
-
-    // check with very high sexually explicit score (well above threshold)
-    final float VERY_HIGH_SEXUALLY_EXPLICIT = .8f;
-
-    inputScores.put(AttributeType.SEXUALLY_EXPLICIT, VERY_HIGH_SEXUALLY_EXPLICIT);
-    input = new PerspectiveValues("foo", inputScores);
-
-    Assert.assertEquals(false, ContentDecisions.makeDecision(input));
-  }
-
-  /**
-   * Check that ContentDecisions makeDecision returns that PerspectiveValues
-   * with low scores for profane material (below 80% threshold) 
-   * is appropriate (thus true as return).
-   */
-  @Test
-  public void checkDecisionForLowProfanity() {
-    // check with a pretty low profanity score (far below 80%)
-    final float VERY_LOW_PROFANITY = .35f;
-
-    inputScores.put(AttributeType.PROFANITY, VERY_LOW_PROFANITY);
-    input = new PerspectiveValues("foo", inputScores);
-
-    Assert.assertTrue(ContentDecisions.makeDecision(input));
-
-    // check with a sexually explicit score just below 80%
-    final float LOW_PROFANITY = .79f;
-    inputScores.put(AttributeType.PROFANITY, LOW_PROFANITY);
-    input = new PerspectiveValues("foo", inputScores);
-
-    Assert.assertTrue(ContentDecisions.makeDecision(input));
-  }
-
-  /**
-   * Check that ContentDecisions makeDecision() returns that PerspectiveValues
-   * with threshold profane material (exactly 80%) is inappropiate 
-   * (thus false as return).
-   */
-  @Test
-  public void checkDecisionForThresholdProfanity() {
-    // check with the threshold sexually explicit score
-    final float THRESHOLD_PROFANITY = .8f;
-
-    inputScores.put(AttributeType.PROFANITY, THRESHOLD_PROFANITY);
-    input = new PerspectiveValues("foo", inputScores);
-
-    Assert.assertEquals(false, ContentDecisions.makeDecision(input));
-  }
-
-  /**
-   * Check that ContentDecisions returns that PerspectiveValues
-   * with highly profane material (above 80% threshold) 
-   * is inappropiate (thus false as return).
-   */
-  @Test
-  public void checkDecisionForHighProfanity() {
-    // check with high profanity score (but just above threshold)
-    final float HIGH_PROFANITY = .81f;
-
-    inputScores.put(AttributeType.PROFANITY, HIGH_PROFANITY);
-    input = new PerspectiveValues("foo", inputScores);
-
-    Assert.assertEquals(false, ContentDecisions.makeDecision(input));
-
-    // check with very high profanity score (well above threshold)
-    final float VERY_HIGH_PROFANITY = .95f;
-
-    inputScores.put(AttributeType.PROFANITY, VERY_HIGH_PROFANITY);
-    input = new PerspectiveValues("foo", inputScores);
-
-    Assert.assertEquals(false, ContentDecisions.makeDecision(input));
-  }
-
-  /**
-   * Check that ContentDecisions makeDecision returns that PerspectiveValues
-   * with low scores for offensive material (below 80% threshold) 
-   * is appropriate (thus true as return).
-   */
-  @Test
-  public void checkDecisionForLowOffensivity() {
-    // check with a pretty low identity attack score (far below 80%)
-    final float VERY_LOW_OFFENSIVITY = .35f;
-
-    inputScores.put(AttributeType.IDENTITY_ATTACK, VERY_LOW_OFFENSIVITY);
-    input = new PerspectiveValues("foo", inputScores);
-
-    Assert.assertTrue(ContentDecisions.makeDecision(input));
-
-    // check with a identity attack score just below 80%
-    final float LOW_OFFENSIVITY = .79f;
-    inputScores.put(AttributeType.IDENTITY_ATTACK, LOW_OFFENSIVITY);
-    input = new PerspectiveValues("foo", inputScores);
-
-    Assert.assertTrue(ContentDecisions.makeDecision(input));
-  }
-
-  /**
-   * Check that ContentDecisions makeDecision() returns that PerspectiveValues
-   * with threshold offensive material (exactly 80%) is inappropiate 
-   * (thus false as return).
-   */
-  @Test
-  public void checkDecisionForThresholdOffensivity() {
-    // check with the threshold identity attack score
-    final float THRESHOLD_OFFENSIVITY = .8f;
-
-    inputScores.put(AttributeType.IDENTITY_ATTACK, THRESHOLD_OFFENSIVITY);
-    input = new PerspectiveValues("foo", inputScores);
-
-    Assert.assertEquals(false, ContentDecisions.makeDecision(input));
-  }
-
-  /**
-   * Check that ContentDecisions returns that PerspectiveValues
-   * with highly offensive material (above 80% threshold) 
-   * is inappropiate (thus false as return).
-   */
-  @Test
-  public void checkDecisionForHighOffensivity() {
-    // check with high identity attack score (but just above threshold)
-    final float HIGH_OFFENSIVITY = .81f;
-
-    inputScores.put(AttributeType.IDENTITY_ATTACK, HIGH_OFFENSIVITY);
-    input = new PerspectiveValues("foo", inputScores);
-
-    Assert.assertEquals(false, ContentDecisions.makeDecision(input));
-
-    // check with very high identity attack score (well above threshold)
-    final float VERY_HIGH_OFFENSIVITY = .95f;
-
-    inputScores.put(AttributeType.IDENTITY_ATTACK, VERY_HIGH_OFFENSIVITY);
-    input = new PerspectiveValues("foo", inputScores);
-
-    Assert.assertEquals(false, ContentDecisions.makeDecision(input));
-  }
-
-  /**
-   * Check that ContentDecisions makeDecision returns that PerspectiveValues
-   * with low scores for obscene material (below 80% threshold) 
-   * is appropriate (thus true as return).
-   */
-  @Test
-  public void checkDecisionForLowObscenity() {
-    // check with a pretty low obscenity score (far below 80%)
-    final float VERY_LOW_OBSCENITY = .35f;
-
-    inputScores.put(AttributeType.OBSCENE, VERY_LOW_OBSCENITY);
-    input = new PerspectiveValues("foo", inputScores);
-
-    Assert.assertTrue(ContentDecisions.makeDecision(input));
-
-    // check with an obscenity score just below 80%
-    final float LOW_OBSCENITY = .79f;
-    inputScores.put(AttributeType.OBSCENE, LOW_OBSCENITY);
-    input = new PerspectiveValues("foo", inputScores);
-
-    Assert.assertTrue(ContentDecisions.makeDecision(input));
-  }
-
-  /**
-   * Check that ContentDecisions makeDecision() returns that PerspectiveValues
-   * with threshold obscene material (exactly 80%) is inappropiate 
-   * (thus false as return).
-   */
-  @Test
-  public void checkDecisionForThresholdObscenity() {
-    // check with the threshold obscene score
-    final float THRESHOLD_OBSCENITY = .8f;
-
-    inputScores.put(AttributeType.OBSCENE, THRESHOLD_OBSCENITY);
-    input = new PerspectiveValues("foo", inputScores);
-
-    Assert.assertEquals(false, ContentDecisions.makeDecision(input));
-  }
-
-  /**
-   * Check that ContentDecisions returns that PerspectiveValues
-   * with highly obscene material (above 80% threshold) 
-   * is inappropiate (thus false as return).
-   */
-  @Test
-  public void checkDecisionForHighObscenity() {
-    // check with high obscenity score (but just above threshold)
-    final float HIGH_OBSCENITY = .81f;
-
-    inputScores.put(AttributeType.OBSCENE, HIGH_OBSCENITY);
-    input = new PerspectiveValues("foo", inputScores);
-
-    Assert.assertEquals(false, ContentDecisions.makeDecision(input));
-
-    // check with very high identity attack score (well above threshold)
-    final float VERY_HIGH_OBSCENITY = .95f;
-
-    inputScores.put(AttributeType.OBSCENE, VERY_HIGH_OBSCENITY);
     input = new PerspectiveValues("foo", inputScores);
 
     Assert.assertEquals(false, ContentDecisions.makeDecision(input));

--- a/backstory/src/test/java/com/google/sps/perspective/ContentDecisionsTest.java
+++ b/backstory/src/test/java/com/google/sps/perspective/ContentDecisionsTest.java
@@ -17,6 +17,7 @@ package com.google.sps.perspective;
 import static org.mockito.Mockito.*;
 
 import au.com.origma.perspectiveapi.v1alpha1.models.AttributeType;
+import com.google.common.collect.ImmutableList;
 import com.google.sps.perspective.data.ContentDecisions;
 import com.google.sps.perspective.data.PerspectiveValues;
 import java.util.HashMap;

--- a/backstory/src/test/java/com/google/sps/perspective/ContentDecisionsTest.java
+++ b/backstory/src/test/java/com/google/sps/perspective/ContentDecisionsTest.java
@@ -52,7 +52,7 @@ public final class ContentDecisionsTest {
   @Before 
   public void setUp() {
     inputScores = new HashMap<AttributeType, Float>();
-    
+
     // set all criteria to 0 at the moment (so default is it's appropriate)
     for (AttributeType type: CRITERIA) {
       inputScores.put(type, 0f);
@@ -129,6 +129,7 @@ public final class ContentDecisionsTest {
     input = new PerspectiveValues(DEFAULT_TEXT, inputScores); 
     ContentDecisions.makeDecision(input); // should be the line causing the error
   }
+  
 
   /**
    * Check that ContentDecisions makeDecision returns that PerspectiveValues


### PR DESCRIPTION
Adapt PerspectiveDecision and the generatePerspectiveDecision method of PerspectiveStoryAnalysisManager to work with needs of the PerspectiveAnalysisManager and avoid NullPointerException (which occurs currently when a not appropriate story is analyzed in demo). Update PerspectiveServlet with this information.

Note: the bug was that in the demo, when a story was judged not appropraite, a NullPointerError was thrown when trying to access its values through the PerspectiveDecision because what actually was returned was not a PerspectiveDecision but was null. This class changed the PerspectiveDecision in order to avoid this.