### PR TITLE
8/19: Add image validation and fix issue where you can submit image before uploading image

### DIFF
--- a/backstory/src/main/java/com/google/sps/perspective/data/ContentDecisions.java
+++ b/backstory/src/main/java/com/google/sps/perspective/data/ContentDecisions.java
@@ -22,8 +22,7 @@ import java.util.Map;
  * is appropriate using analysis from Perspective API.
  */
 public class ContentDecisions {
-  
-  // threshold here means that score must be below this threshold 
+  // threshold here means that score must be below this threshold
   // in order to be considered appropriate.
 
   /** the threshold for appropriateness for toxicity score */
@@ -61,17 +60,16 @@ public class ContentDecisions {
     return !isToxic(scores) && !isSexuallyExplicit(scores) && !isProfane(scores)
         && !isOffensive(scores) && !isObscene(scores);
   }
-  
+
   /**
    * Validate both that the map isn't null and that the map has a score.
-   * 
+   *
    * @param attributeTypesToScores the map to be validating
    * @param attributeType the type to check it has a score for
    * @throws IllegalArgumentException if the map is null or doesn't have the score
    */
-  private static void validateMapHasScore(Map<AttributeType, Float> attributeTypesToScores, 
-    AttributeType attributeType) throws IllegalArgumentException {
-
+  private static void validateMapHasScore(Map<AttributeType, Float> attributeTypesToScores,
+      AttributeType attributeType) throws IllegalArgumentException {
     if (attributeTypesToScores == null) {
       throw new IllegalArgumentException("Map (attributeTypesToScores) cannot be null.");
     } else if (!attributeTypesToScores.containsKey(attributeType)) {

--- a/backstory/src/main/webapp/index.html
+++ b/backstory/src/main/webapp/index.html
@@ -41,11 +41,11 @@
         ><span class="yellow-header">o</span><span class="pink-header">r</span><span class="red-header">y</span>
       </h1>
 
-      <form id="photo-upload" method="post" enctype="multipart/form-data">
+      <form id="photo-upload" onsubmit="return checkForm();" method="post" enctype="multipart/form-data">
         <div class="vertical-flex-container" id="photo-upload-div">
           <label id="upload-label" for="image-upload">Upload Your Image Here...</label>
           <input class="file-input" type="file" id="image-upload" name="image-upload" onchange="uploadFileUpdates()" />
-          <button type="submit" id="submit-button" onclick="createBackstoryLoadingElement()" disabled>Submit</button>
+          <button type="submit" id="submit-button" disabled=>Submit</button>
         </div>
       </form>
 

--- a/backstory/src/main/webapp/index.html
+++ b/backstory/src/main/webapp/index.html
@@ -43,9 +43,9 @@
 
       <form id="photo-upload" method="post" enctype="multipart/form-data">
         <div class="vertical-flex-container" id="photo-upload-div">
-          <label id="upload-label" for="image-upload">Upload Your Image...</label>
-          <input class="file-input" type="file" id="image-upload" name="image-upload" onchange="updateFileName()" />
-          <button type="submit" id="submit-button" onclick="createBackstoryLoadingElement()">Submit</button>
+          <label id="upload-label" for="image-upload">Upload Your Image Here...</label>
+          <input class="file-input" type="file" id="image-upload" name="image-upload" onchange="uploadFileUpdates()" />
+          <button type="submit" id="submit-button" onclick="createBackstoryLoadingElement()" disabled>Submit</button>
         </div>
       </form>
 

--- a/backstory/src/main/webapp/index.html
+++ b/backstory/src/main/webapp/index.html
@@ -45,7 +45,7 @@
         <div class="vertical-flex-container" id="photo-upload-div">
           <label id="upload-label" for="image-upload">Upload Your Image Here...</label>
           <input class="file-input" type="file" id="image-upload" name="image-upload" onchange="uploadFileUpdates()" />
-          <button type="submit" id="submit-button" disabled=>Submit</button>
+          <button type="submit" id="submit-button" disabled>Submit</button>
         </div>
       </form>
 

--- a/backstory/src/main/webapp/script.js
+++ b/backstory/src/main/webapp/script.js
@@ -29,7 +29,7 @@
  * @return true, if image is valid, false otherwise
  */
 function checkForm() {
-  if (! validateImageUpload()) {
+  if (!validateImageUpload()) {
     return false;
   }
 
@@ -222,14 +222,12 @@ function updateFileName() {
 }
 
 /**
- * Enables the submit button if there's a file in
- * the image-upload field.
+ * Enables the submit button if there's a valid image upload.
  */
 function enableSubmitButton() {
-  const fileInput = document.getElementById('image-upload');
   const submitButton = document.getElementById('submit-button');
 
-  if (fileInput.files.length > 0) {
+  if (validateImageUpload()) {
     submitButton.disabled = false;
   }
 }

--- a/backstory/src/main/webapp/script.js
+++ b/backstory/src/main/webapp/script.js
@@ -18,7 +18,7 @@
  */
 
 /* exported fetchBlobstoreUrl getAnalyzedImages
-   createBackstoryLoadingElement updateFileName */
+   createBackstoryLoadingElement uploadFileUpdates */
 
 // FETCH BLOBSTORE URL
 
@@ -137,7 +137,7 @@ function createBackstoryLoadingElement() {
 
 // UPLOAD FILE CHANGES
 
-/** 
+/**
  * Updates the text of the file upload when a file is uploaded
  * and enables the submit button (starts as
  * a disabled button in HTML).
@@ -165,7 +165,7 @@ function updateFileName() {
 }
 
 /**
- * Enables the submit button if there's a file in 
+ * Enables the submit button if there's a file in
  * the image-upload field.
  */
 function enableSubmitButton() {

--- a/backstory/src/main/webapp/script.js
+++ b/backstory/src/main/webapp/script.js
@@ -14,7 +14,7 @@
 
 /* JS for Home page
  * features: get blobstore url, retrieve analyzed images,
- * create loading element, and update file upload label
+ * create loading element, and change CSS/HTML when file is uploaded.
  */
 
 /* exported fetchBlobstoreUrl getAnalyzedImages
@@ -135,7 +135,17 @@ function createBackstoryLoadingElement() {
   }
 }
 
-// UPDATE FILE UPLOAD LABEL
+// UPLOAD FILE CHANGES
+
+/** 
+ * Updates the text of the file upload when a file is uploaded
+ * and enables the submit button (starts as
+ * a disabled button in HTML).
+ */
+function uploadFileUpdates() {
+  updateFileName();
+  enableSubmitButton();
+}
 
 /**
  * Updates the text of the file upload label to match the uploaded file
@@ -151,5 +161,18 @@ function updateFileName() {
     } else {
       label.innerText = fileInput.files.item(0).name;
     }
+  }
+}
+
+/**
+ * Enables the submit button if there's a file in 
+ * the image-upload field.
+ */
+function enableSubmitButton() {
+  const fileInput = document.getElementById('image-upload');
+  const submitButton = document.getElementById('submit-button');
+
+  if (fileInput.files.length > 0) {
+    submitButton.disabled = false;
   }
 }

--- a/backstory/src/main/webapp/script.js
+++ b/backstory/src/main/webapp/script.js
@@ -13,12 +13,69 @@
 // limitations under the License.
 
 /* JS for Home page
- * features: get blobstore url, retrieve analyzed images,
- * create loading element, and change CSS/HTML when file is uploaded.
+ * features: validate form, get blobstore url, retrieve analyzed images,
+ * create loading element, and updates to front end when file uploaded.
  */
 
-/* exported fetchBlobstoreUrl getAnalyzedImages
-   createBackstoryLoadingElement uploadFileUpdates */
+/* exported checkForm fetchBlobstoreUrl getAnalyzedImages uploadFileUpdates*/
+
+// VALIDATE FORM WITH IMAGE UPLOAD
+
+/**
+ * Check the form by validating image upload 
+ * and if it's valid return true and add
+ * the loading graphic. 
+ *
+ * @return true, if image is valid, false otherwise
+ */
+function checkForm() {
+  let validImageUploaded = validateImageUpload();
+
+  if (! validImageUploaded) {
+    return false;
+  }
+
+  createBackstoryLoadingElement();
+  return true;
+}
+
+/**
+ * Validate that the file uploaded to image upload
+ * is an accepted image. Alert user to upload a new file if not.
+ *
+ * @return true, if valid image uploaded; false, if no image uploaded
+ *      or if no valid image uploaded  
+ */
+function validateImageUpload() {
+  const imageUpload = document.getElementById('image-upload');
+  const files = imageUpload.files;
+
+  if (files.length === 0) {
+    alert('No file has been uploaded. Please upload a file.');
+    return false;
+  }
+  
+  if (! validImage(files.item(0))) {
+    alert('Only PNGs and JPGs are accepted image upload types. ' 
+        + 'Please upload a PNG or JPG.');
+    return false;
+  }
+
+  return true;
+}
+
+/** 
+ * Validate that the passed-in file is an
+ * accepted image type (jpg or png).
+ *
+ * @param file - the file to validate
+ * @return true, if file exists & is a valid image, false otherwise
+ */
+function validImage(file) {
+  const acceptedImageTypes = ['image/jpeg', 'image/png'];
+
+  return file && acceptedImageTypes.includes(file['type']);
+}
 
 // FETCH BLOBSTORE URL
 
@@ -74,8 +131,6 @@ function getAnalyzedImages() {
       });
 }
 
-// CREATE LOADING ELEMENT
-
 /**
  * Helper function to format the image and backstory combination into one
  * element. This element and it's components have classes added to them for
@@ -104,10 +159,13 @@ function createBackstoryElement(imageUrl, backstory) {
   return backstoryElement;
 }
 
+// CREATE LOADING ELEMENT
+
 /**
  * Helper function to create and set a loading element to display after the
  * photo-upload form is submitted, while image is being analyzed and the
- * backstory is being created.
+ * backstory is being created. Only execute this function if valid
+ * image uploaded.
  */
 function createBackstoryLoadingElement() {
   const backstoryLoadingIcon = document.createElement('div');

--- a/backstory/src/main/webapp/script.js
+++ b/backstory/src/main/webapp/script.js
@@ -22,16 +22,14 @@
 // VALIDATE FORM WITH IMAGE UPLOAD
 
 /**
- * Check the form by validating image upload 
+ * Check the form by validating image upload
  * and if it's valid return true and add
- * the loading graphic. 
+ * the loading graphic.
  *
  * @return true, if image is valid, false otherwise
  */
 function checkForm() {
-  let validImageUploaded = validateImageUpload();
-
-  if (! validImageUploaded) {
+  if (! validateImageUpload()) {
     return false;
   }
 
@@ -44,7 +42,7 @@ function checkForm() {
  * is an accepted image. Alert user to upload a new file if not.
  *
  * @return true, if valid image uploaded; false, if no image uploaded
- *      or if no valid image uploaded  
+ *      or if no valid image uploaded
  */
 function validateImageUpload() {
   const imageUpload = document.getElementById('image-upload');
@@ -54,17 +52,18 @@ function validateImageUpload() {
     alert('No file has been uploaded. Please upload a file.');
     return false;
   }
-  
-  if (! validImage(files.item(0))) {
-    alert('Only PNGs and JPGs are accepted image upload types. ' 
-        + 'Please upload a PNG or JPG.');
+
+  if (!validImage(files.item(0))) {
+    alert(
+        'Only PNGs and JPGs are accepted image upload types. ' +
+        'Please upload a PNG or JPG.');
     return false;
   }
 
   return true;
 }
 
-/** 
+/**
  * Validate that the passed-in file is an
  * accepted image type (jpg or png).
  *

--- a/backstory/src/main/webapp/style.css
+++ b/backstory/src/main/webapp/style.css
@@ -144,13 +144,13 @@ textarea {
 }
 
 #photo-upload-div {
- align-items: center;
+  align-items: center;
 }
 
 #upload-label {
   cursor: pointer;
   font-weight: bold;
-  padding: 0px 0px 10px;
+  padding: 0 0 10px;
 }
 
 #submit-button {

--- a/backstory/src/main/webapp/style.css
+++ b/backstory/src/main/webapp/style.css
@@ -143,18 +143,14 @@ textarea {
   padding: 20px 0 10px;
 }
 
-#home-content #photo-upload {
-  text-align: center;
+#photo-upload-div {
+ align-items: center;
 }
 
-#home-content #image-upload {
-  background-color: white;
-  border: solid thick var(--saffron);
-  border-radius: 5px;
-  color: var(--oxford-blue) !important;
-  font-size: 16px;
+#upload-label {
+  cursor: pointer;
   font-weight: bold;
-  padding: 0 0 10px;
+  padding: 0px 0px 10px;
 }
 
 #submit-button {
@@ -167,6 +163,10 @@ textarea {
   height: 40px;
   margin: 0 10px 25px;
   width: 100px;
+}
+
+#submit-button:disabled {
+  visibility: hidden;
 }
 
 #story-display {


### PR DESCRIPTION
Add image validation and clean up minor front end critiques.

Fix #164 by not allowing users to submit the image upload form without submitting an image. First, does this by having the submit button be disabled and invisible until image is uploaded. Second, add validation that image is uploaded before sending the request (alerts user if image is not uploaded). Second method is unnecessary, but good extra security. Also, add validation that image submitted is a PNG or JPG/JPEG image, and alert user if not (also don't send post request/load loading graphic). Also add "here" to the image upload label to make UI more understandable.