### PR TITLE
8/26: Add image analysis to enable adding location to prompt

### DIFF
--- a/backstory/src/main/java/com/google/sps/images/VisionImagesManager.java
+++ b/backstory/src/main/java/com/google/sps/images/VisionImagesManager.java
@@ -86,7 +86,7 @@ public final class VisionImagesManager implements ImagesManager {
 
     // TODO: parallelize calls to detectLabelsFromImageBytes() since it requires a network call.
     if (!(responses.size() == size)) {
-      throw new IllegalArgumentException(
+      throw new RuntimeException(
           "The number of responses is not equal to the number of requests.");
     }
 

--- a/backstory/src/main/java/com/google/sps/images/VisionImagesManager.java
+++ b/backstory/src/main/java/com/google/sps/images/VisionImagesManager.java
@@ -46,61 +46,67 @@ public final class VisionImagesManager implements ImagesManager {
   }
 
   /**
-   * Creates a vision manager object using a mock image annotator client.
+   * Creates a vision manager object using a passed-in image annotator client.
+   *
+   * @param imageAnnotatorClient the client to use to analyze the image
    */
   public VisionImagesManager(ImageAnnotatorClient imageAnnotatorClient) {
     this.imageAnnotatorClient = imageAnnotatorClient;
   }
 
   @Override
-  public List<AnnotatedImage> createAnnotatedImagesFromImagesAsByteArrays(
-      List<byte[]> imagesAsByteArrays) throws IOException {
-    List<AnnotatedImage> annotatedImages = new ArrayList<>();
+  public List<AnnotatedImage> createAnnotatedImagesFromImagesAsByteArrays(List<byte[]> imagesAsByteArrays)
+    throws IOException {
+    List<AnnotateImageRequest> requests = new ArrayList<AnnotateImageRequest>();
+
+    // add the features we want (labels & landmarks to list)
+    List<Feature> features = new ArrayList<Feature>();
+
+    Feature labelFeature = Feature.newBuilder().setType(Feature.Type.LABEL_DETECTION).build();
+    Feature landmarkFeature = Feature.newBuilder().setType(Feature.Type.LANDMARK_DETECTION).build();
+
+    features.add(labelFeature);
+    features.add(landmarkFeature);
+
+    // iterate through the images to build the request
+    int size = imagesAsByteArrays.size();
+
+    for (int i = 0; i < size; i++){
+      Image image = Image.newBuilder().setContent(ByteString.copyFrom(imagesAsByteArrays.get(i))).build();
+      AnnotateImageRequest request =
+        AnnotateImageRequest.newBuilder().addAllFeatures(features).setImage(image).build();
+      requests.add(request);
+    }
 
     // TODO: parallelize calls to detectLabelsFromImageBytes() since it requires a network call.
-    for (byte[] rawImageData : imagesAsByteArrays) {
-      List<EntityAnnotation> labelAnnotations = detectLabelsFromImageBytes(rawImageData);
-      AnnotatedImage annotatedImage = new AnnotatedImage(rawImageData, labelAnnotations);
-      annotatedImages.add(annotatedImage);
+
+    // The invocation of batchAnnotateImages() makes a network call.
+    BatchAnnotateImagesResponse batchResponse = imageAnnotatorClient.batchAnnotateImages(requests);
+    List<AnnotateImageResponse> responses = batchResponse.getResponsesList();
+
+    // TODO: parallelize calls to detectLabelsFromImageBytes() since it requires a network call.
+    if (!(responses.size() == size)) {
+      throw new IllegalArgumentException(
+          "The number of responses is not equal to the number of requests.");
+    }
+
+    List<AnnotatedImage> annotatedImages = new ArrayList<AnnotatedImage>();
+
+    // add an annotated image to list for every image received as byte array
+    for (int i = 0; i < responses.size(); i++) {
+      AnnotateImageResponse response = responses.get(i);
+
+      if (response.hasError()) {
+        throw new IOException(response.getError().getMessage());
+      }
+
+      // For full list of available annotations, see http://g.co/cloud/vision/docs
+      List<EntityAnnotation> labels = response.getLabelAnnotationsList();
+      List<EntityAnnotation> locations = response.getLandmarkAnnotationsList();
+
+      annotatedImages.add(new AnnotatedImage(imagesAsByteArrays.get(i), labels, locations));
     }
 
     return annotatedImages;
-  }
-
-  /**
-   * Creates and returns label annotations for the image represented in bytes, using the Vision API.
-   *
-   * @param bytes The raw image byte data for the image from which labels will be annotated.
-   * @return The list of label annotations related to the image, with each individual label being
-   *     represented as an EntityAnnotation object.
-   */
-  private List<EntityAnnotation> detectLabelsFromImageBytes(byte[] bytes) throws IOException {
-    List<AnnotateImageRequest> requests = new ArrayList<>();
-    List<EntityAnnotation> labels;
-
-    Image img = Image.newBuilder().setContent(ByteString.copyFrom(bytes)).build();
-    Feature feat = Feature.newBuilder().setType(Feature.Type.LABEL_DETECTION).build();
-    AnnotateImageRequest request =
-        AnnotateImageRequest.newBuilder().addFeatures(feat).setImage(img).build();
-    requests.add(request);
-
-    // The invocation of batchAnnotateImages() makes a network call.
-    BatchAnnotateImagesResponse response = imageAnnotatorClient.batchAnnotateImages(requests);
-    List<AnnotateImageResponse> responses = response.getResponsesList();
-
-    // TODO: parallelize calls to detectLabelsFromImageBytes() since it requires a network call.
-    if (!(responses.size() == 1)) {
-      throw new IllegalArgumentException(
-          "detectLabelsFromImageBytes only supports analytics on one image");
-    }
-    AnnotateImageResponse res = responses.get(0);
-
-    if (res.hasError()) {
-      throw new IOException(res.getError().getMessage());
-    }
-
-    // For full list of available annotations, see http://g.co/cloud/vision/docs
-    labels = res.getLabelAnnotationsList();
-    return labels;
   }
 }

--- a/backstory/src/main/java/com/google/sps/images/VisionImagesManager.java
+++ b/backstory/src/main/java/com/google/sps/images/VisionImagesManager.java
@@ -55,8 +55,8 @@ public final class VisionImagesManager implements ImagesManager {
   }
 
   @Override
-  public List<AnnotatedImage> createAnnotatedImagesFromImagesAsByteArrays(List<byte[]> imagesAsByteArrays)
-    throws IOException {
+  public List<AnnotatedImage> createAnnotatedImagesFromImagesAsByteArrays(
+      List<byte[]> imagesAsByteArrays) throws IOException {
     List<AnnotateImageRequest> requests = new ArrayList<AnnotateImageRequest>();
 
     // add the features we want (labels & landmarks to list)
@@ -71,10 +71,11 @@ public final class VisionImagesManager implements ImagesManager {
     // iterate through the images to build the request
     int size = imagesAsByteArrays.size();
 
-    for (int i = 0; i < size; i++){
-      Image image = Image.newBuilder().setContent(ByteString.copyFrom(imagesAsByteArrays.get(i))).build();
+    for (int i = 0; i < size; i++) {
+      Image image =
+          Image.newBuilder().setContent(ByteString.copyFrom(imagesAsByteArrays.get(i))).build();
       AnnotateImageRequest request =
-        AnnotateImageRequest.newBuilder().addAllFeatures(features).setImage(image).build();
+          AnnotateImageRequest.newBuilder().addAllFeatures(features).setImage(image).build();
       requests.add(request);
     }
 
@@ -86,8 +87,7 @@ public final class VisionImagesManager implements ImagesManager {
 
     // TODO: parallelize calls to detectLabelsFromImageBytes() since it requires a network call.
     if (!(responses.size() == size)) {
-      throw new RuntimeException(
-          "The number of responses is not equal to the number of requests.");
+      throw new RuntimeException("The number of responses is not equal to the number of requests.");
     }
 
     List<AnnotatedImage> annotatedImages = new ArrayList<AnnotatedImage>();

--- a/backstory/src/main/java/com/google/sps/images/data/AnnotatedImage.java
+++ b/backstory/src/main/java/com/google/sps/images/data/AnnotatedImage.java
@@ -50,7 +50,7 @@ public final class AnnotatedImage {
   /** labels describing the picture */
   private final List<EntityAnnotation> labelAnnotations;
   /** the possible locations for this picture */
-  private final List<EntityAnnotation> landmarkAnnotations; 
+  private final List<EntityAnnotation> landmarkAnnotations;
 
   /**
    * Instantiates the AnnotatedImage object parameterized with a byte array of raw image data and
@@ -61,10 +61,10 @@ public final class AnnotatedImage {
    * @param labelAnnotations the preset labels to annotate the image with. Must be non-null.
    * @param landmarkAnnotations the locations of this photo. Must be non-null.
    */
-  public AnnotatedImage(byte[] rawImageData, List<EntityAnnotation> labelAnnotations, 
-    List<EntityAnnotation> landmarkAnnotations)
-      throws IllegalArgumentException {
-    if (rawImageData == null || labelAnnotations == null || landmarkAnnotations == null | rawImageData.length == 0) {
+  public AnnotatedImage(byte[] rawImageData, List<EntityAnnotation> labelAnnotations,
+      List<EntityAnnotation> landmarkAnnotations) throws IllegalArgumentException {
+    if (rawImageData == null || labelAnnotations == null
+        || landmarkAnnotations == null | rawImageData.length == 0) {
       throw new IllegalArgumentException(
           "Raw image data must be non-null and non-empty, label annotation data must be non-null");
     }
@@ -118,8 +118,8 @@ public final class AnnotatedImage {
     return descriptions;
   }
 
-  /** 
-   * Return the bytes representing the image 
+  /**
+   * Return the bytes representing the image
    *
    * @return byte representation of image held in this class
    */
@@ -127,17 +127,17 @@ public final class AnnotatedImage {
     return Arrays.copyOf(rawImageData, rawImageData.length);
   }
 
-  /** 
-   * Return the labels annotated to the image 
+  /**
+   * Return the labels annotated to the image
    *
    * @return the labels annotations for this image
    */
   public List<EntityAnnotation> getLabelAnnotations() {
     return Collections.unmodifiableList(labelAnnotations);
   }
-  
-  /** 
-   * Return the landmarks annotated to the image 
+
+  /**
+   * Return the landmarks annotated to the image
    *
    * @return landmarks annotated to this class
    */

--- a/backstory/src/main/java/com/google/sps/images/data/AnnotatedImage.java
+++ b/backstory/src/main/java/com/google/sps/images/data/AnnotatedImage.java
@@ -102,6 +102,22 @@ public final class AnnotatedImage {
     return descriptions;
   }
 
+  /**
+   * Returns only the "description" field, for all image landmark annotations.
+   *
+   * @return list of "description" fields for all landmarks returned by Vision API's
+   *     getLandmarkAnnotationsList method.
+   */
+  public List<String> getLandmarkDescriptions() {
+    List<String> descriptions = new ArrayList<String>();
+
+    for (EntityAnnotation landmarkAnnotation : landmarkAnnotations) {
+      descriptions.add(landmarkAnnotation.getDescription());
+    }
+
+    return descriptions;
+  }
+
   /** 
    * Return the bytes representing the image 
    *
@@ -119,7 +135,7 @@ public final class AnnotatedImage {
   public List<EntityAnnotation> getLabelAnnotations() {
     return Collections.unmodifiableList(labelAnnotations);
   }
-
+  
   /** 
    * Return the landmarks annotated to the image 
    *

--- a/backstory/src/main/java/com/google/sps/images/data/AnnotatedImage.java
+++ b/backstory/src/main/java/com/google/sps/images/data/AnnotatedImage.java
@@ -45,8 +45,12 @@ import java.util.List;
  * rawImageData) as a defensive copy.
  */
 public final class AnnotatedImage {
+  /** the byte representation of the image data */
   private final byte[] rawImageData;
+  /** labels describing the picture */
   private final List<EntityAnnotation> labelAnnotations;
+  /** the possible locations for this picture */
+  private final List<EntityAnnotation> landmarkAnnotations; 
 
   /**
    * Instantiates the AnnotatedImage object parameterized with a byte array of raw image data and
@@ -55,16 +59,19 @@ public final class AnnotatedImage {
    * @param rawImageData The raw image data for the image being represented in this VisionManager
    *     object. Must be non-empty and non-null.
    * @param labelAnnotations the preset labels to annotate the image with. Must be non-null.
+   * @param landmarkAnnotations the locations of this photo. Must be non-null.
    */
-  public AnnotatedImage(byte[] rawImageData, List<EntityAnnotation> labelAnnotations)
+  public AnnotatedImage(byte[] rawImageData, List<EntityAnnotation> labelAnnotations, 
+    List<EntityAnnotation> landmarkAnnotations)
       throws IllegalArgumentException {
-    if (rawImageData == null || labelAnnotations == null || rawImageData.length == 0) {
+    if (rawImageData == null || labelAnnotations == null || landmarkAnnotations == null | rawImageData.length == 0) {
       throw new IllegalArgumentException(
           "Raw image data must be non-null and non-empty, label annotation data must be non-null");
     }
 
     this.rawImageData = rawImageData;
     this.labelAnnotations = labelAnnotations;
+    this.landmarkAnnotations = landmarkAnnotations;
   }
 
   /**
@@ -95,13 +102,30 @@ public final class AnnotatedImage {
     return descriptions;
   }
 
-  /** Return the bytes representing the image */
+  /** 
+   * Return the bytes representing the image 
+   *
+   * @return byte representation of image held in this class
+   */
   public byte[] getRawImageData() {
     return Arrays.copyOf(rawImageData, rawImageData.length);
   }
 
-  /** Return the labels annotated to the image */
+  /** 
+   * Return the labels annotated to the image 
+   *
+   * @return the labels annotations for this image
+   */
   public List<EntityAnnotation> getLabelAnnotations() {
     return Collections.unmodifiableList(labelAnnotations);
+  }
+
+  /** 
+   * Return the landmarks annotated to the image 
+   *
+   * @return landmarks annotated to this class
+   */
+  public List<EntityAnnotation> getLandmarkAnnotations() {
+    return Collections.unmodifiableList(landmarkAnnotations);
   }
 }

--- a/backstory/src/test/java/com/google/sps/images/AnnotatedImageTest.java
+++ b/backstory/src/test/java/com/google/sps/images/AnnotatedImageTest.java
@@ -50,7 +50,8 @@ import com.google.sps.images.data.AnnotatedImage;
 public final class AnnotatedImageTest {
   private static final byte[] nullRawImageData = null;
   private static final byte[] emptyRawImageData = new byte[0];
-  private static final List<EntityAnnotation> emptyLabelAnnotations = new ArrayList<>();
+  private static final List<EntityAnnotation> emptyLabelAnnotations = new ArrayList<EntityAnnotation>();
+  private static final List<EntityAnnotation> emptyLandmarkAnnotations = new ArrayList<EntityAnnotation>();
 
   /**
    * Create a mock entity annotation with a description field set.
@@ -85,33 +86,36 @@ public final class AnnotatedImageTest {
   }
 
   /**
-   * public AnnotatedImage(byte[] rawImageData, List<EntityAnnotation> labelAnnotations);
+   * public AnnotatedImage(byte[] rawImageData, List<EntityAnnotation> labelAnnotations, List<EntityAnottation landmarkAnnotations);
    *  rawImageData is null.
    *  labelAnnotations is empty.
+   *  landmarkAnnotations is empty.
    *  Expects IllegalArgumentException to be thrown.
   */
   @Test(expected = IllegalArgumentException.class)
   public void constructorNullImageData() throws IllegalArgumentException {
-    new AnnotatedImage(nullRawImageData, emptyLabelAnnotations);
+    new AnnotatedImage(nullRawImageData, emptyLabelAnnotations, emptyLandmarkAnnotations);
   }
 
   /**
-   * public AnnotatedImage(byte[] rawImageData, List<EntityAnnotation> labelAnnotations);
+   * public AnnotatedImage(byte[] rawImageData, List<EntityAnnotation> labelAnnotations, List<EntityAnnotation> landmarkAnnotations);
    *  rawImageData is empty.
    *  labelAnnotations is non-empty.
+   *  landmarkAnnotations is empty.
    *  Expects IllegalArgumentException to be thrown.
   */
   @Test(expected = IllegalArgumentException.class)
   public void constructorEmptyImageData() throws IllegalArgumentException {
     List<EntityAnnotation> labelAnnotations = new ArrayList<>();
     labelAnnotations.add(makeMockEntityAnnotationWithDescription("Description")); 
-    new AnnotatedImage(emptyRawImageData, labelAnnotations);
+    new AnnotatedImage(emptyRawImageData, labelAnnotations, emptyLandmarkAnnotations);
   }
 
   /**
-   * public AnnotatedImage(byte[] rawImageData, List<EntityAnnotation> labelAnnotations);
+   * public AnnotatedImage(byte[] rawImageData, List<EntityAnnotation> labelAnnotations, List<EntityAnnotation> landmarkAnnotations);
    *  rawImageData is non-empty image data.
    *  labelAnnotations is non-empty.
+   *  landmarkAnnotations is empty.
   */
   @Test
   public void constructorRawImageData() throws IllegalArgumentException, IOException {
@@ -125,7 +129,7 @@ public final class AnnotatedImageTest {
       throw exception;
     }
 
-    AnnotatedImage actualAnnotatedImage = new AnnotatedImage(rawImageData, labelAnnotations);
+    AnnotatedImage actualAnnotatedImage = new AnnotatedImage(rawImageData, labelAnnotations, emptyLandmarkAnnotations);
     assertTrue(Arrays.equals(rawImageData, actualAnnotatedImage.getRawImageData()));
     assertEquals(labelAnnotations, actualAnnotatedImage.getLabelAnnotations());
   }
@@ -144,7 +148,7 @@ public final class AnnotatedImageTest {
       throw exception;
     }
         
-    AnnotatedImage annotatedImage = new AnnotatedImage(rawImageData, emptyLabelAnnotations);
+    AnnotatedImage annotatedImage = new AnnotatedImage(rawImageData, emptyLabelAnnotations, emptyLandmarkAnnotations);
     assertEquals(new ArrayList<>(), annotatedImage.getLabelDescriptions());
   }
 
@@ -167,7 +171,7 @@ public final class AnnotatedImageTest {
       throw exception;
     }
 
-    AnnotatedImage annotatedImageActual = new AnnotatedImage(rawImageData, labelAnnotations);
+    AnnotatedImage annotatedImageActual = new AnnotatedImage(rawImageData, labelAnnotations, emptyLandmarkAnnotations);
     List<String> actualLabelDescriptions = annotatedImageActual.getLabelDescriptions();
     List<String> expectedLabelDescriptions = new ArrayList<>();
     expectedLabelDescriptions.add("DescriptionOne");

--- a/backstory/src/test/java/com/google/sps/images/AnnotatedImageTest.java
+++ b/backstory/src/test/java/com/google/sps/images/AnnotatedImageTest.java
@@ -92,35 +92,54 @@ public final class AnnotatedImageTest {
    *  landmarkAnnotations is empty.
    *  Expects IllegalArgumentException to be thrown.
   */
-  @Test(expected = IllegalArgumentException.class)
+  @Test (expected = IllegalArgumentException.class)
   public void constructorNullImageData() throws IllegalArgumentException {
     new AnnotatedImage(nullRawImageData, emptyLabelAnnotations, emptyLandmarkAnnotations);
   }
 
   /**
    * public AnnotatedImage(byte[] rawImageData, List<EntityAnnotation> labelAnnotations, List<EntityAnnotation> landmarkAnnotations);
-   *  rawImageData is empty.
-   *  labelAnnotations is non-empty.
+   *  rawImageData is non-empty.
+   *  labelAnnotations is null
    *  landmarkAnnotations is empty.
    *  Expects IllegalArgumentException to be thrown.
   */
-  @Test(expected = IllegalArgumentException.class)
-  public void constructorEmptyImageData() throws IllegalArgumentException {
-    List<EntityAnnotation> labelAnnotations = new ArrayList<>();
-    labelAnnotations.add(makeMockEntityAnnotationWithDescription("Description")); 
-    new AnnotatedImage(emptyRawImageData, labelAnnotations, emptyLandmarkAnnotations);
+  @Test (expected = IllegalArgumentException.class)
+  public void constructorNullLabelAnnotations() throws IllegalArgumentException, IOException {
+    byte[] rawImageData = getBytesFromImageReference(
+        "src/test/java/com/google/sps/images/data/dogRunningOnBeach.jpg", "jpg");
+
+    new AnnotatedImage(rawImageData, null, emptyLandmarkAnnotations);
+  }
+
+  /**
+   * public AnnotatedImage(byte[] rawImageData, List<EntityAnnotation> labelAnnotations, List<EntityAnottation landmarkAnnotations);
+   *  rawImageData is non-empty.
+   *  labelAnnotations is empty.
+   *  landmarkAnnotations is null.
+   *  Expects IllegalArgumentException to be thrown.
+  */
+  @Test (expected = IllegalArgumentException.class)
+  public void constructorNullLandmarkAnnotations() throws IllegalArgumentException, IOException {
+    byte[] rawImageData = getBytesFromImageReference(
+        "src/test/java/com/google/sps/images/data/dogRunningOnBeach.jpg", "jpg");
+
+    new AnnotatedImage(rawImageData, emptyLabelAnnotations, null);
   }
 
   /**
    * public AnnotatedImage(byte[] rawImageData, List<EntityAnnotation> labelAnnotations, List<EntityAnnotation> landmarkAnnotations);
    *  rawImageData is non-empty image data.
    *  labelAnnotations is non-empty.
-   *  landmarkAnnotations is empty.
+   *  landmarkAnnotations is non-empty.
   */
   @Test
   public void constructorRawImageData() throws IllegalArgumentException, IOException {
     List<EntityAnnotation> labelAnnotations = new ArrayList<>();
     labelAnnotations.add(makeMockEntityAnnotationWithDescription("Description"));
+    List<EntityAnnotation> landmarkAnnotations = new ArrayList<EntityAnnotation>();
+    landmarkAnnotations.add(makeMockEntityAnnotationWithDescription("Description"));
+
     byte[] rawImageData;
     try {
       rawImageData = getBytesFromImageReference(
@@ -129,9 +148,10 @@ public final class AnnotatedImageTest {
       throw exception;
     }
 
-    AnnotatedImage actualAnnotatedImage = new AnnotatedImage(rawImageData, labelAnnotations, emptyLandmarkAnnotations);
+    AnnotatedImage actualAnnotatedImage = new AnnotatedImage(rawImageData, labelAnnotations, landmarkAnnotations);
     assertTrue(Arrays.equals(rawImageData, actualAnnotatedImage.getRawImageData()));
     assertEquals(labelAnnotations, actualAnnotatedImage.getLabelAnnotations());
+    assertEquals(landmarkAnnotations, actualAnnotatedImage.getLandmarkAnnotations());
   }
 
   /**
@@ -174,9 +194,56 @@ public final class AnnotatedImageTest {
     AnnotatedImage annotatedImageActual = new AnnotatedImage(rawImageData, labelAnnotations, emptyLandmarkAnnotations);
     List<String> actualLabelDescriptions = annotatedImageActual.getLabelDescriptions();
     List<String> expectedLabelDescriptions = new ArrayList<>();
-    expectedLabelDescriptions.add("DescriptionOne");
-    expectedLabelDescriptions.add("DescriptionTwo");
+    expectedLabelDescriptions.add(firstAnnotationDescription);
+    expectedLabelDescriptions.add(secondAnnotationDescription);
 
     assertEquals(expectedLabelDescriptions, actualLabelDescriptions);
+  }
+
+  /**
+   * public List<String> getLandmarkDescriptions();
+   *  landmarkAnnotations is empty.
+  */
+  @Test
+  public void getLandmarkDescriptionsEmptyLandmarkAnnotations() throws IllegalArgumentException, IOException {
+    byte[] rawImageData;
+    try {
+      rawImageData = getBytesFromImageReference(
+        "src/test/java/com/google/sps/images/data/dogRunningOnBeach.jpg", "jpg");
+    } catch (IOException exception) {
+      throw exception;
+    }
+        
+    AnnotatedImage annotatedImage = new AnnotatedImage(rawImageData, emptyLabelAnnotations, emptyLandmarkAnnotations);
+    assertEquals(new ArrayList<String>(), annotatedImage.getLandmarkDescriptions());
+  }
+
+  /**
+   * public List<String> getLandmarkDescriptions();
+   *  landmarkAnnotations is a non-empty list of EntityAnnotations.
+  */
+  @Test
+  public void getLandmarkDescriptionsNonEmptyLandmarkAnnotations() throws IllegalArgumentException, IOException {
+    List<EntityAnnotation> landmarkAnnotations = new ArrayList<EntityAnnotation>();
+    String firstAnnotationDescription = "DescriptionOne";
+    String secondAnnotationDescription = "DescriptionTwo";
+    landmarkAnnotations.add(makeMockEntityAnnotationWithDescription(firstAnnotationDescription));
+    landmarkAnnotations.add(makeMockEntityAnnotationWithDescription(secondAnnotationDescription)); 
+    
+    byte[] rawImageData;
+    try {
+      rawImageData = getBytesFromImageReference(
+        "src/test/java/com/google/sps/images/data/dogRunningOnBeach.jpg", "jpg");
+    } catch (IOException exception) {
+      throw exception;
+    }
+
+    AnnotatedImage annotatedImageActual = new AnnotatedImage(rawImageData, emptyLabelAnnotations, landmarkAnnotations);
+    List<String> actualLandmarkDescriptions = annotatedImageActual.getLandmarkDescriptions();
+    List<String> expectedLandmarkDescriptions = new ArrayList<String>();
+    expectedLandmarkDescriptions.add(firstAnnotationDescription);
+    expectedLandmarkDescriptions.add(secondAnnotationDescription);
+
+    assertEquals(expectedLandmarkDescriptions, actualLandmarkDescriptions);
   }
 }

--- a/backstory/src/test/java/com/google/sps/images/AnnotatedImageTest.java
+++ b/backstory/src/test/java/com/google/sps/images/AnnotatedImageTest.java
@@ -86,12 +86,12 @@ public final class AnnotatedImageTest {
   }
 
   /**
-   * public AnnotatedImage(byte[] rawImageData, List<EntityAnnotation> labelAnnotations, List<EntityAnottation landmarkAnnotations);
+   * public AnnotatedImage(byte[] rawImageData, List<EntityAnnotation> labelAnnotations, List<EntityAnnotation landmarkAnnotations);
    *  rawImageData is null.
    *  labelAnnotations is empty.
    *  landmarkAnnotations is empty.
    *  Expects IllegalArgumentException to be thrown.
-  */
+   */
   @Test (expected = IllegalArgumentException.class)
   public void constructorNullImageData() throws IllegalArgumentException {
     new AnnotatedImage(nullRawImageData, emptyLabelAnnotations, emptyLandmarkAnnotations);
@@ -103,7 +103,7 @@ public final class AnnotatedImageTest {
    *  labelAnnotations is null
    *  landmarkAnnotations is empty.
    *  Expects IllegalArgumentException to be thrown.
-  */
+   */
   @Test (expected = IllegalArgumentException.class)
   public void constructorNullLabelAnnotations() throws IllegalArgumentException, IOException {
     byte[] rawImageData = getBytesFromImageReference(
@@ -118,7 +118,7 @@ public final class AnnotatedImageTest {
    *  labelAnnotations is empty.
    *  landmarkAnnotations is null.
    *  Expects IllegalArgumentException to be thrown.
-  */
+   */
   @Test (expected = IllegalArgumentException.class)
   public void constructorNullLandmarkAnnotations() throws IllegalArgumentException, IOException {
     byte[] rawImageData = getBytesFromImageReference(
@@ -132,7 +132,7 @@ public final class AnnotatedImageTest {
    *  rawImageData is non-empty image data.
    *  labelAnnotations is non-empty.
    *  landmarkAnnotations is non-empty.
-  */
+   */
   @Test
   public void constructorRawImageData() throws IllegalArgumentException, IOException {
     List<EntityAnnotation> labelAnnotations = new ArrayList<>();
@@ -140,13 +140,8 @@ public final class AnnotatedImageTest {
     List<EntityAnnotation> landmarkAnnotations = new ArrayList<EntityAnnotation>();
     landmarkAnnotations.add(makeMockEntityAnnotationWithDescription("Description"));
 
-    byte[] rawImageData;
-    try {
-      rawImageData = getBytesFromImageReference(
-        "src/test/java/com/google/sps/images/data/dogRunningOnBeach.jpg", "jpg");
-    } catch (IOException exception) {
-      throw exception;
-    }
+    byte[] rawImageData = getBytesFromImageReference(
+      "src/test/java/com/google/sps/images/data/dogRunningOnBeach.jpg", "jpg");
 
     AnnotatedImage actualAnnotatedImage = new AnnotatedImage(rawImageData, labelAnnotations, landmarkAnnotations);
     assertTrue(Arrays.equals(rawImageData, actualAnnotatedImage.getRawImageData()));
@@ -157,16 +152,12 @@ public final class AnnotatedImageTest {
   /**
    * public List<String> getLabelDescriptions();
    *  labelAnnotations is empty.
-  */
+   */
   @Test
   public void getLabelDescriptionsEmptyLabelAnnotations() throws IllegalArgumentException, IOException {
-    byte[] rawImageData;
-    try {
-      rawImageData = getBytesFromImageReference(
+    byte[] rawImageData = getBytesFromImageReference(
         "src/test/java/com/google/sps/images/data/dogRunningOnBeach.jpg", "jpg");
-    } catch (IOException exception) {
-      throw exception;
-    }
+
         
     AnnotatedImage annotatedImage = new AnnotatedImage(rawImageData, emptyLabelAnnotations, emptyLandmarkAnnotations);
     assertEquals(new ArrayList<>(), annotatedImage.getLabelDescriptions());
@@ -175,24 +166,21 @@ public final class AnnotatedImageTest {
   /**
    * public List<String> getLabelDescriptions();
    *  labelAnnotations is a non-empty list of EntityAnnotations.
-  */
+   */
   @Test
   public void getLabelDescriptionsNonEmptyLabelAnnotations() throws IllegalArgumentException, IOException {
-    List<EntityAnnotation> labelAnnotations = new ArrayList<>();
+    List<EntityAnnotation> labelAnnotations = new ArrayList<EntityAnnotation>();
+
     String firstAnnotationDescription = "DescriptionOne";
     String secondAnnotationDescription = "DescriptionTwo";
     labelAnnotations.add(makeMockEntityAnnotationWithDescription(firstAnnotationDescription));
     labelAnnotations.add(makeMockEntityAnnotationWithDescription(secondAnnotationDescription)); 
-    byte[] rawImageData;
-    try {
-      rawImageData = getBytesFromImageReference(
-        "src/test/java/com/google/sps/images/data/dogRunningOnBeach.jpg", "jpg");
-    } catch (IOException exception) {
-      throw exception;
-    }
 
-    AnnotatedImage annotatedImageActual = new AnnotatedImage(rawImageData, labelAnnotations, emptyLandmarkAnnotations);
-    List<String> actualLabelDescriptions = annotatedImageActual.getLabelDescriptions();
+    byte[] rawImageData = getBytesFromImageReference(
+        "src/test/java/com/google/sps/images/data/dogRunningOnBeach.jpg", "jpg");
+
+    AnnotatedImage actualAnnotatedImage = new AnnotatedImage(rawImageData, labelAnnotations, emptyLandmarkAnnotations);
+    List<String> actualLabelDescriptions = actualAnnotatedImage.getLabelDescriptions();
     List<String> expectedLabelDescriptions = new ArrayList<>();
     expectedLabelDescriptions.add(firstAnnotationDescription);
     expectedLabelDescriptions.add(secondAnnotationDescription);
@@ -203,16 +191,11 @@ public final class AnnotatedImageTest {
   /**
    * public List<String> getLandmarkDescriptions();
    *  landmarkAnnotations is empty.
-  */
+   */
   @Test
   public void getLandmarkDescriptionsEmptyLandmarkAnnotations() throws IllegalArgumentException, IOException {
-    byte[] rawImageData;
-    try {
-      rawImageData = getBytesFromImageReference(
+    byte[] rawImageData = getBytesFromImageReference(
         "src/test/java/com/google/sps/images/data/dogRunningOnBeach.jpg", "jpg");
-    } catch (IOException exception) {
-      throw exception;
-    }
         
     AnnotatedImage annotatedImage = new AnnotatedImage(rawImageData, emptyLabelAnnotations, emptyLandmarkAnnotations);
     assertEquals(new ArrayList<String>(), annotatedImage.getLandmarkDescriptions());
@@ -221,7 +204,7 @@ public final class AnnotatedImageTest {
   /**
    * public List<String> getLandmarkDescriptions();
    *  landmarkAnnotations is a non-empty list of EntityAnnotations.
-  */
+   */
   @Test
   public void getLandmarkDescriptionsNonEmptyLandmarkAnnotations() throws IllegalArgumentException, IOException {
     List<EntityAnnotation> landmarkAnnotations = new ArrayList<EntityAnnotation>();
@@ -230,16 +213,11 @@ public final class AnnotatedImageTest {
     landmarkAnnotations.add(makeMockEntityAnnotationWithDescription(firstAnnotationDescription));
     landmarkAnnotations.add(makeMockEntityAnnotationWithDescription(secondAnnotationDescription)); 
     
-    byte[] rawImageData;
-    try {
-      rawImageData = getBytesFromImageReference(
+    byte[] rawImageData= getBytesFromImageReference(
         "src/test/java/com/google/sps/images/data/dogRunningOnBeach.jpg", "jpg");
-    } catch (IOException exception) {
-      throw exception;
-    }
 
-    AnnotatedImage annotatedImageActual = new AnnotatedImage(rawImageData, emptyLabelAnnotations, landmarkAnnotations);
-    List<String> actualLandmarkDescriptions = annotatedImageActual.getLandmarkDescriptions();
+    AnnotatedImage actualAnnotatedImage = new AnnotatedImage(rawImageData, emptyLabelAnnotations, landmarkAnnotations);
+    List<String> actualLandmarkDescriptions = actualAnnotatedImage.getLandmarkDescriptions();
     List<String> expectedLandmarkDescriptions = new ArrayList<String>();
     expectedLandmarkDescriptions.add(firstAnnotationDescription);
     expectedLandmarkDescriptions.add(secondAnnotationDescription);

--- a/backstory/src/test/java/com/google/sps/images/VisionImagesManagerTest.java
+++ b/backstory/src/test/java/com/google/sps/images/VisionImagesManagerTest.java
@@ -103,15 +103,13 @@ public final class VisionImagesManagerTest {
 
     // Create the ImagesManager with the mock image annotator client
     ImagesManager manager = new VisionImagesManager(mockImageAnnotatorClient);
-
-    // Use the ImageAnnotatorClient to check the response given  to it
+    // Call the analysis method
     manager.createAnnotatedImagesFromImagesAsByteArrays(rawImageDataList);
 
-    // Check that the request is as expected
+    // Capture the requests argument
     ArgumentCaptor<List<AnnotateImageRequest>> argument = ArgumentCaptor.forClass(List.class);
     verify(mockImageAnnotatorClient).batchAnnotateImages(argument.capture());
     List<AnnotateImageRequest> requests = argument.getValue();
-    Assert.assertEquals(rawImageDataList.size(), requests.size());
 
     // Check that features we want are requested
     List<Feature> expectedFeatures = new ArrayList<Feature>();
@@ -122,9 +120,10 @@ public final class VisionImagesManagerTest {
     expectedFeatures.add(labelFeature);
     expectedFeatures.add(landmarkFeature);
     
-    for (AnnotateImageRequest request: requests) {
-      Assert.assertEquals(expectedFeatures, request.getFeaturesList());
-    }
+    // Check the request is as expected 
+    Assert.assertEquals(1, requests.size());
+    AnnotateImageRequest request = requests.get(0);
+    Assert.assertEquals(expectedFeatures, request.getFeaturesList());
   }
 
   /** 


### PR DESCRIPTION
Add analysis of image with Landmark Detection feature of Cloud Vision. Adjust AnnotatedImage to store the labelAnnotations. Add testing for both of these adjustments. Resolves #118.